### PR TITLE
Add GitHub action PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,66 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: |
+            ~/.cargo
+            target
+      - name: Check
+        run: cargo check
+
+  clippy:
+    runs-on: ubuntu-20.04
+    needs: [check]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: |
+            ~/.cargo
+            target
+      - name: Clippy
+        run: cargo clippy
+
+  doc-check:
+    runs-on: ubuntu-20.04
+    needs: [check]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: |
+            ~/.cargo
+            target
+      - name: Doc check
+        run: cargo doc --no-deps
+
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: cargo test
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -374,28 +374,36 @@ pub enum Replacement {
 forward_display_to_serde!(Replacement);
 forward_from_str_to_serde!(Replacement);
 
-/// Indicates which resource attribute is triggering this update.
-#[derive(Debug, enumset::EnumSetType, serde::Deserialize, serde::Serialize)]
-#[enumset(no_ops, serialize_as_list)]
-pub enum ModifyScope {
-    /// A change to the resource's properties.
-    Properties,
+// The derive for EnumSetType creates an item that triggers this lint, so it has to be disabled
+// at the module level. We don't want to disable it too broadly though, so we wrap its declaration
+// in a module and re-export from that.
+mod modify_scope {
+    #![allow(clippy::expl_impl_clone_on_copy)]
 
-    /// A change to the resource's metadata.
-    Metadata,
+    /// Indicates which resource attribute is triggering this update.
+    #[derive(Debug, enumset::EnumSetType, serde::Deserialize, serde::Serialize)]
+    #[enumset(no_ops, serialize_as_list)]
+    pub enum ModifyScope {
+        /// A change to the resource's properties.
+        Properties,
 
-    /// A change to the resource's creation policy.
-    CreationPolicy,
+        /// A change to the resource's metadata.
+        Metadata,
 
-    /// A change to the resource's update policy.
-    UpdatePolicy,
+        /// A change to the resource's creation policy.
+        CreationPolicy,
 
-    /// A change to the resource's deletion policy.
-    DeletionPolicy,
+        /// A change to the resource's update policy.
+        UpdatePolicy,
 
-    /// A change to the resource's tags.
-    Tags,
+        /// A change to the resource's deletion policy.
+        DeletionPolicy,
+
+        /// A change to the resource's tags.
+        Tags,
+    }
 }
+pub use modify_scope::ModifyScope;
 
 forward_display_to_serde!(ModifyScope);
 forward_from_str_to_serde!(ModifyScope);


### PR DESCRIPTION
- a652d4b **ci: Add pull request workflow**

  The `pr` workflow triggers on pull requests against master and runs
  `clippy`, `test`, and `doc`. `RUST[DOC]FLAGS=-D warnings` is used to
  promote warnings to errors when supported.

- 9c14a4f **fix: Fix expl_impl_clone_on_copy lint**

  This was being triggered by the derive for EnumSetType, which generates
  an item that triggers the lint. It wasn't seen until now due to
  [rust-lang/rust-clippy#4612][1], which was only fixed in Rust 1.52.0.
  
  [1]: https://github.com/rust-lang/rust-clippy/issues/4612
