### PR TITLE
Run check and clippy against all artifacts

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,13 +14,20 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Cache
+      - name: Cargo cache
         uses: actions/cache@v2
         with:
           key: ${{ github.sha }}
           path: |
-            ~/.cargo
-            target
+            ~/.cargo/bin
+            ~/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+      - name: Check cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: target
       - name: Check
         run: cargo check --all-targets
 
@@ -29,13 +36,20 @@ jobs:
     needs: [check]
     steps:
       - uses: actions/checkout@v2
-      - name: Cache
+      - name: Cargo cache
         uses: actions/cache@v2
         with:
           key: ${{ github.sha }}
           path: |
-            ~/.cargo
-            target
+            ~/.cargo/bin
+            ~/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+      - name: Check cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: target
       - name: Clippy
         run: cargo clippy --all-targets
 
@@ -44,20 +58,37 @@ jobs:
     needs: [check]
     steps:
       - uses: actions/checkout@v2
-      - name: Cache
+      - name: Cargo cache
         uses: actions/cache@v2
         with:
           key: ${{ github.sha }}
           path: |
-            ~/.cargo
-            target
+            ~/.cargo/bin
+            ~/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+      - name: Check cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: target
       - name: Doc check
         run: cargo doc --no-deps
 
   test:
     runs-on: ubuntu-20.04
+    needs: [check]
     steps:
       - uses: actions/checkout@v2
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ github.sha }}
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git/db
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
       - name: Test
         run: cargo test
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
             ~/.cargo
             target
       - name: Check
-        run: cargo check
+        run: cargo check --all-targets
 
   clippy:
     runs-on: ubuntu-20.04
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo
             target
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets
 
   doc-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- 38d81d2 **ci: Run check and clippy against all targets**

  `cargo check` and `cargo clippy` both operate against only the lib and
  bins by default, but we want to check everything. Currently this only
  affects tests, but we shall appreciate our foresight if we ever add
  benches/bins/examples...

- 690c2f2 **ci: Improve caching in PR workflow**

  The caching now properly covers cargo packages and metadata, and this is
  used in `cargo test`. The `target` cache is separated, and still only
  usable with `clippy` and `doc`.
