### PR TITLE
Prep 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
 name = "cloudformatious"
-version = "0.1.0-rc.0"
+version = "0.1.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"
-description = "Extension traits for rusoto_cloudformation (WIP)"
+description = "Extension traits for rusoto_cloudformation"
 repository = "https://github.com/connec/cloudformatious"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-stream = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![crates.io](https://img.shields.io/crates/v/cloudformatious?logo=rust&style=flat-square)](https://crates.io/crates/cloudformatious)
 [![docs.rs](https://img.shields.io/docsrs/cloudformatious?logo=rust&style=flat-square)](https://docs.rs/cloudformatious)
 
-⚠️ This crate is WIP.
-
 An extension trait for [`rusoto_cloudformation::CloudFormationClient`](https://docs.rs/rusoto_cloudformation/0.46.0/rusoto_cloudformation/struct.CloudFormationClient.html) offering richly typed higher-level APIs to perform long-running operations and await their termination or observe their progress.
 
 ```rust + no_run
@@ -46,9 +44,7 @@ This makes it possible to implement fairly advanced workflows involving things l
 There are other tools that can mitigate this, such as the `aws cloudformation deploy` high-level command, but their output is very limited so they only really do half of the work.
 Furthermore, the tools that I'm aware of are primarily invoked from the shell, meaning they cannot be integrated natively into programs that wish to orchestrate CloudFormation stacks.
 
-Also, I like CloudFormation and programming in Rust so this is fun for me 🤷‍♂️
-
-## Current status
+## Features
 
 The `CloudFormatious` extension trait has the following methods:
 
@@ -62,12 +58,10 @@ In both cases, the API is a bit more ergonomic than `rusoto_cloudformation` and 
 In particular:
 
 - The return value of both methods implements `Future`, which can be `await`ed to wait for the overall operation to end.
-- The return value of both methods has an `events()` method, which can be used to get `Stream` of stack events that occur during the operation.
+- The return value of both methods has an `events()` method, which can be used to get a `Stream` of stack events that occur during the operation.
 - Both methods return rich `Err` values if the stack settles in a failing state.
 - Both methods return rich `Err` values if the stack operation succeeds, but some resource(s) had errors (these "warnings" can be ignored, but it may mean leaving extraneous infrastructure in your environment).
 - `apply_stack` returns a rich `Ok` value with 'cleaner' types than the generated `rusoto_cloudformation` types.
-
-This is enough for my current use-cases.
 
 ## Contributing
 

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -154,6 +154,7 @@ impl ApplyStackInput {
     /// Set the value for `capabilities`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_capabilities(mut self, capabilities: impl Into<Vec<Capability>>) -> Self {
         self.capabilities = capabilities.into();
         self
@@ -162,6 +163,7 @@ impl ApplyStackInput {
     /// Set the value for `client_request_token`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_client_request_token(mut self, client_request_token: impl Into<String>) -> Self {
         self.client_request_token = Some(client_request_token.into());
         self
@@ -170,6 +172,7 @@ impl ApplyStackInput {
     /// Set the value for `notification_arns`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_notification_arns<I, S>(mut self, notification_arns: I) -> Self
     where
         I: Into<Vec<S>>,
@@ -186,6 +189,7 @@ impl ApplyStackInput {
     /// Set the value for `parameters`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_parameters(mut self, parameters: impl Into<Vec<Parameter>>) -> Self {
         self.parameters = parameters.into();
         self
@@ -194,6 +198,7 @@ impl ApplyStackInput {
     /// Set the value for `resource_types`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_resource_types<I, S>(mut self, resource_types: I) -> Self
     where
         I: Into<Vec<S>>,
@@ -206,6 +211,7 @@ impl ApplyStackInput {
     /// Set the value for `role_arn`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_role_arn(mut self, role_arn: impl Into<String>) -> Self {
         self.role_arn = Some(role_arn.into());
         self
@@ -214,6 +220,7 @@ impl ApplyStackInput {
     /// Set the value for `tags`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_tags(mut self, tags: impl Into<Vec<Tag>>) -> Self {
         self.tags = tags.into();
         self
@@ -459,7 +466,7 @@ impl ApplyStackOutput {
 }
 
 /// An output from an `apply_stack` operation.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct StackOutput {
     /// User defined description associated with the output.
     pub description: Option<String>,
@@ -691,8 +698,9 @@ impl Future for ApplyStack<'_> {
                             .expect("end of stream without err or output"),
                     )
                 }
-                task::Poll::Ready(Some(Ok(ApplyStackEvent::ChangeSet(_))))
-                | task::Poll::Ready(Some(Ok(ApplyStackEvent::Event(_)))) => continue,
+                task::Poll::Ready(Some(Ok(
+                    ApplyStackEvent::ChangeSet(_) | ApplyStackEvent::Event(_),
+                ))) => continue,
                 task::Poll::Ready(Some(Ok(ApplyStackEvent::Output(output)))) => {
                     self.output.replace(Ok(output));
                     continue;

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -214,9 +214,11 @@ pub struct ResourceChange {
 
 impl ResourceChange {
     fn from_raw(change: Change) -> Self {
-        if change.type_.as_deref() != Some("Resource") {
-            panic!("Change with unexpected type_ {:?}", change.type_);
-        }
+        assert!(
+            change.type_.as_deref() == Some("Resource"),
+            "Change with unexpected type_ {:?}",
+            change.type_
+        );
         let change = change
             .resource_change
             .expect("Change without resource_change");

--- a/src/delete_stack.rs
+++ b/src/delete_stack.rs
@@ -90,6 +90,7 @@ impl DeleteStackInput {
     /// Set the value for `client_request_token`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_client_request_token(mut self, client_request_token: impl Into<String>) -> Self {
         self.client_request_token = Some(client_request_token.into());
         self
@@ -98,6 +99,7 @@ impl DeleteStackInput {
     /// Set the value for `client_request_token`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_retain_resources<I, S>(mut self, retain_resources: I) -> Self
     where
         I: Into<Vec<S>>,
@@ -116,6 +118,7 @@ impl DeleteStackInput {
     /// Set the value for `role_arn`.
     ///
     /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
     pub fn set_role_arn(mut self, role_arn: impl Into<String>) -> Self {
         self.role_arn = Some(role_arn.into());
         self

--- a/tests/apply_stack.rs
+++ b/tests/apply_stack.rs
@@ -256,23 +256,20 @@ async fn create_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
     {
         assert_eq!(stack_status, StackStatus::RollbackComplete);
         assert!(stack_status_reason.contains("resource(s) failed to create: [Vpc]"));
-        assert_eq!(
-            resource_events
-                .iter()
-                .map(|(status, details)| {
-                    (
-                        details.logical_resource_id(),
-                        *status,
-                        details.resource_status_reason().inner(),
-                    )
-                })
-                .collect::<Vec<_>>(),
-            vec![(
-                "Vpc",
-                ResourceStatus::CreateFailed,
-                Some("Property CidrBlock cannot be empty.")
-            )]
-        );
+        let resource_errors = resource_events
+            .iter()
+            .map(|(status, details)| {
+                (
+                    details.logical_resource_id(),
+                    *status,
+                    details.resource_status_reason().inner(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            &resource_errors[..],
+            [("Vpc", ResourceStatus::CreateFailed, Some(_))]
+        ));
     } else {
         return Err(error.into());
     }
@@ -306,6 +303,7 @@ async fn create_stack_stream_err() -> Result<(), Box<dyn std::error::Error>> {
         events,
         vec![
             (stack_name.clone(), "CREATE_IN_PROGRESS".to_string()),
+            ("Vpc".to_string(), "CREATE_IN_PROGRESS".to_string()),
             ("Vpc".to_string(), "CREATE_FAILED".to_string()),
             (stack_name.clone(), "ROLLBACK_IN_PROGRESS".to_string()),
             ("Vpc".to_string(), "DELETE_COMPLETE".to_string()),
@@ -321,23 +319,20 @@ async fn create_stack_stream_err() -> Result<(), Box<dyn std::error::Error>> {
     {
         assert_eq!(stack_status, StackStatus::RollbackComplete);
         assert!(stack_status_reason.contains("resource(s) failed to create: [Vpc]"));
-        assert_eq!(
-            resource_events
-                .iter()
-                .map(|(status, details)| {
-                    (
-                        details.logical_resource_id(),
-                        *status,
-                        details.resource_status_reason().inner(),
-                    )
-                })
-                .collect::<Vec<_>>(),
-            vec![(
-                "Vpc",
-                ResourceStatus::CreateFailed,
-                Some("Property CidrBlock cannot be empty.")
-            )]
-        );
+        let resource_errors = resource_events
+            .iter()
+            .map(|(status, details)| {
+                (
+                    details.logical_resource_id(),
+                    *status,
+                    details.resource_status_reason().inner(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            &resource_errors[..],
+            [("Vpc", ResourceStatus::CreateFailed, Some(_))]
+        ));
     } else {
         return Err(error.into());
     }
@@ -382,23 +377,20 @@ async fn update_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
     {
         assert_eq!(stack_status, StackStatus::UpdateRollbackComplete);
         assert!(stack_status_reason.contains("resource(s) failed to create: [Vpc]"));
-        assert_eq!(
-            resource_events
-                .iter()
-                .map(|(status, details)| {
-                    (
-                        details.logical_resource_id(),
-                        *status,
-                        details.resource_status_reason().inner(),
-                    )
-                })
-                .collect::<Vec<_>>(),
-            vec![(
-                "Vpc",
-                ResourceStatus::CreateFailed,
-                Some("Property CidrBlock cannot be empty.")
-            )]
-        );
+        let resource_errors = resource_events
+            .iter()
+            .map(|(status, details)| {
+                (
+                    details.logical_resource_id(),
+                    *status,
+                    details.resource_status_reason().inner(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            &resource_errors[..],
+            [("Vpc", ResourceStatus::CreateFailed, Some(_))]
+        ));
     } else {
         return Err(error.into());
     }

--- a/tests/cloudformatious-testing.yaml
+++ b/tests/cloudformatious-testing.yaml
@@ -29,7 +29,6 @@ Resources:
           - Sid: SubnetOperations1
             Effect: Allow
             Action:
-              - ec2:CreateTags
               - ec2:DeleteSubnet
             Resource: '*'
             Condition:
@@ -38,8 +37,9 @@ Resources:
           - Sid: SubnetOperations2
             Effect: Allow
             Action:
+              - ec2:CreateTags
               - ec2:DescribeSubnets
-            Resource: '*' # There is no way of restricting this operation to just our subnets
+            Resource: '*' # There is no way of restricting these operations to just our subnets
 
   Vpc:
     Type: AWS::EC2::VPC


### PR DESCRIPTION
- 9ba5612 **chore: fix lint errors**


- 20f9777 **chore: fix tests**

  Some tests were broken by changes in VPC/Subnet APIs (or
  CloudFormation's handling thereof). Specifically:
  
  - VPC resources now have a `CREATE_IN_PROGRESS` even with a missing
    `CidrBlock` property (suggesting that CloudFormation previously
    validated the presence of `CidrBlock` itself, or else performed a
    separate validation routine, whereas now it's handled by EC2).
  
  - Similarly, the error message for a VPC missing a `CidrBlock` has
    changed to note that either `CidrBlock` *or* an IPAM pool need to be
    provided. This presumably motivated the change in validation
    behaviour.
  
  - Creating subnets with tags no longer includes the `ec2:Vpc` condition
    key. Sadly this means there's no longer any way to restrict the
    `ec2:CreateTags` action in the integration test policy. A very sneaky
    breaking change!

- 9aca6ea **chore: update README in preparation for 0.1.0**

  This removes some "not ready" implications and 1st person prose.

- a3637fd **chore: bump version**

  Also remove the "WIP" tag.
