### PR TITLE
Handle spooky `SecretsManager::Secret` change sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/tests/cloudformatious-testing.yaml
+++ b/tests/cloudformatious-testing.yaml
@@ -40,6 +40,13 @@ Resources:
               - ec2:CreateTags
               - ec2:DescribeSubnets
             Resource: '*' # There is no way of restricting these operations to just our subnets
+          - Sid: SecretsManagerOperations
+            Effect: Allow
+            Action:
+              - secretsmanager:CreateSecret
+              - secretsmanager:DeleteSecret
+              - secretsmanager:TagResource
+            Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:cloudformatious-testing-*
           - Sid: DecodeAuthorizationMessage
             Effect: Allow
             Action:

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -75,6 +75,32 @@ pub const AUTHORIZATION_FAILURE_TEMPLATE: &str = r#"{
   }
 }"#;
 
+pub const SECRETS_MANAGER_SECRET: &str = r#"{
+    "Parameters": {
+        "TagValue": {
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "Secret": {
+            "Type": "AWS::SecretsManager::Secret",
+            "Properties": {
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "Tags": [
+                    {
+                        "Key": "Key",
+                        "Value": {
+                            "Ref": "TagValue"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}"#;
+
 pub fn get_client() -> CloudFormationClient {
     get_arbitrary_client(CloudFormationClient::new_with)
 }


### PR DESCRIPTION
- ba60e1c **fix: handle spooky `SecretsManager::Secret` change sets**

  For some reason, CloudFormation reports changes to tags on
  `SecretsManager::Secret` resources as "conditionally" requiring
  recreation which violates the assertion that tag changes shall never
  require recreation.
  
  This is being treated as a bug in CloudFormation, and a specific
  exclusion for `AWS::SecretsManager::Secret` resources has been
  introduced.
  
  Fixes #9.

- 2ef811a **chore: bump version**

