### PR TITLE
Migrate from rusoto to aws-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,13 @@ aws-sdk-cloudformation = "0.19.0"
 aws-sdk-sts = "0.19.0"
 aws-smithy-types-convert = { version = "0.49.0", features = ["convert-chrono"] }
 chrono = "0.4.19"
-enumset = { version = "1.0.6", features = ["serde"] }
+enumset = "1.0.6"
 futures-util = "0.3.14"
 lazy_static = "1.4.0"
+parse-display = { version = "0.6.0", default-features = false }
 regex = "1.5.4"
-serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.85"
-serde_plain = "0.3.0"
-tokio = { version = "1.4.0" }
+tokio = "1.4.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,21 @@ repository = "https://github.com/connec/cloudformatious"
 
 [dependencies]
 async-stream = "0.3.0"
+aws-config = "0.49.0"
+aws-sdk-cloudformation = "0.19.0"
+aws-sdk-sts = "0.19.0"
+aws-smithy-types-convert = { version = "0.49.0", features = ["convert-chrono"] }
 chrono = "0.4.19"
 enumset = { version = "1.0.6", features = ["serde"] }
 futures-util = "0.3.14"
 lazy_static = "1.4.0"
-memmem = "0.1.1"
 regex = "1.5.4"
-rusoto_cloudformation = "0.46.0"
-rusoto_core = "0.46.0"
-rusoto_sts = "0.46"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.85"
 serde_plain = "0.3.0"
-tokio = { version = "1.4.0", features = ["time"] }
+tokio = { version = "1.4.0" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 fastrand = "1.4.0"
-rusoto_credential = "0.46.0"
+tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 An extension trait for [`rusoto_cloudformation::CloudFormationClient`](https://docs.rs/rusoto_cloudformation/0.46.0/rusoto_cloudformation/struct.CloudFormationClient.html) offering richly typed higher-level APIs to perform long-running operations and await their termination or observe their progress.
 
-```rust + no_run
+```rust,no_run
 use futures_util::StreamExt;
 use rusoto_cloudformation::CloudFormationClient;
 use rusoto_core::Region;

--- a/README.md
+++ b/README.md
@@ -3,18 +3,17 @@
 [![crates.io](https://img.shields.io/crates/v/cloudformatious?logo=rust&style=flat-square)](https://crates.io/crates/cloudformatious)
 [![docs.rs](https://img.shields.io/docsrs/cloudformatious?logo=rust&style=flat-square)](https://docs.rs/cloudformatious)
 
-An extension trait for [`rusoto_cloudformation::CloudFormationClient`](https://docs.rs/rusoto_cloudformation/0.46.0/rusoto_cloudformation/struct.CloudFormationClient.html) offering richly typed higher-level APIs to perform long-running operations and await their termination or observe their progress.
+A CloudFormation library offering richly typed higher-level APIs to perform long-running operations and await their termination or observe their progress.
 
 ```rust,no_run
 use futures_util::StreamExt;
-use rusoto_cloudformation::CloudFormationClient;
-use rusoto_core::Region;
 
-use cloudformatious::{ApplyStackInput, CloudFormatious, DeleteStackInput, TemplateSource};
+use cloudformatious::{ApplyStackInput, DeleteStackInput, TemplateSource};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = CloudFormationClient::new(Region::EuWest2);
+    let config = aws_config::load_from_env().await;
+    let client = cloudformatious::Client::new(&config);
 
     let input = ApplyStackInput::new("my-stack", TemplateSource::inline("{}"));
     let mut stack = client.apply_stack(input);
@@ -54,14 +53,14 @@ The `CloudFormatious` extension trait has the following methods:
 [`apply_stack`]: https://docs.rs/cloudformatious/latest/cloudformatious/trait.CloudFormatious.html#method.apply_stack
 [`delete_stack`]: https://docs.rs/cloudformatious/latest/cloudformatious/trait.CloudFormatious.html#method.delete_stack
 
-In both cases, the API is a bit more ergonomic than `rusoto_cloudformation` and the API is richer.
+In both cases, the API is a bit more ergonomic than `aws_sdk_cloudformation` and the API is richer.
 In particular:
 
 - The return value of both methods implements `Future`, which can be `await`ed to wait for the overall operation to end.
 - The return value of both methods has an `events()` method, which can be used to get a `Stream` of stack events that occur during the operation.
 - Both methods return rich `Err` values if the stack settles in a failing state.
 - Both methods return rich `Err` values if the stack operation succeeds, but some resource(s) had errors (these "warnings" can be ignored, but it may mean leaving extraneous infrastructure in your environment).
-- `apply_stack` returns a rich `Ok` value with 'cleaner' types than the generated `rusoto_cloudformation` types.
+- `apply_stack` returns a rich `Ok` value with 'cleaner' types than the generated `aws_sdk_cloudformation` types (fewer redundant `Option`s, `enum`s for mutually exclusive states, etc.).
 
 ## Contributing
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,9 +1,7 @@
 use std::{convert::TryInto, env, io, process};
 
-use cloudformatious::{ApplyStackInput, CloudFormatious, DeleteStackInput, TemplateSource};
+use cloudformatious::{ApplyStackInput, Client, DeleteStackInput, TemplateSource};
 use futures_util::StreamExt;
-use rusoto_cloudformation::CloudFormationClient;
-use rusoto_core::Region;
 
 const USAGE: &str = "Usage: cargo run --example cli -- <apply|delete> <stack_name> [template_body]";
 
@@ -23,7 +21,8 @@ async fn try_main() -> Result<(), Box<dyn std::error::Error>> {
         .try_into()
         .map_err(|_| USAGE)?;
 
-    let client = CloudFormationClient::new(Region::default());
+    let config = aws_config::load_from_env().await;
+    let client = Client::new(&config);
 
     match op.as_str() {
         "apply" => {

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -9,7 +9,6 @@ use aws_sdk_cloudformation::{
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use chrono::{DateTime, Utc};
 use futures_util::{Stream, TryFutureExt, TryStreamExt};
-use serde_plain::{forward_display_to_serde, forward_from_str_to_serde};
 
 use crate::{
     change_set::{
@@ -316,18 +315,18 @@ impl ApplyStackInput {
 /// [2]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html
 /// [`AWS::Include`]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html
 /// [`AWS::Serverless`]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
 pub enum Capability {
     /// Acknowledge IAM resources (*without* custom names only).
-    #[serde(rename = "CAPABILITY_IAM")]
+    #[display("CAPABILITY_IAM")]
     Iam,
 
     /// Acknowledge IAM resources (with or without custom names).
-    #[serde(rename = "CAPABILITY_NAMED_IAM")]
+    #[display("CAPABILITY_NAMED_IAM")]
     NamedIam,
 
     /// Acknowledge macro expansion.
-    #[serde(rename = "CAPABILITY_AUTO_EXPAND")]
+    #[display("CAPABILITY_AUTO_EXPAND")]
     AutoExpand,
 }
 
@@ -340,9 +339,6 @@ impl Capability {
         }
     }
 }
-
-forward_display_to_serde!(Capability);
-forward_from_str_to_serde!(Capability);
 
 /// An input parameter for an `apply_stack` operation.
 ///
@@ -855,4 +851,25 @@ async fn describe_output(
         .pop()
         .expect("DescribeStacksOutput empty stacks");
     Ok(ApplyStackOutput::from_raw(stack))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Capability;
+
+    #[test]
+    fn test_parse_display() {
+        assert_eq!(Capability::Iam.to_string(), "CAPABILITY_IAM");
+        assert_eq!(Capability::Iam, "CAPABILITY_IAM".parse().unwrap());
+        assert_eq!(Capability::NamedIam.to_string(), "CAPABILITY_NAMED_IAM");
+        assert_eq!(
+            Capability::NamedIam,
+            "CAPABILITY_NAMED_IAM".parse().unwrap(),
+        );
+        assert_eq!(Capability::AutoExpand.to_string(), "CAPABILITY_AUTO_EXPAND");
+        assert_eq!(
+            Capability::AutoExpand,
+            "CAPABILITY_AUTO_EXPAND".parse().unwrap(),
+        );
+    }
 }

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -13,7 +13,6 @@ use aws_smithy_types_convert::date_time::DateTimeExt;
 use chrono::{DateTime, Utc};
 use enumset::EnumSet;
 use futures_util::TryFutureExt;
-use serde_plain::{forward_display_to_serde, forward_from_str_to_serde};
 use tokio::time::{interval_at, Instant};
 
 use crate::{
@@ -179,8 +178,8 @@ impl ChangeSet {
 }
 
 /// The change set's execution status.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
+#[display(style = "SNAKE_CASE")]
 pub enum ExecutionStatus {
     /// The change set is not available to execute.
     Unavailable,
@@ -200,9 +199,6 @@ pub enum ExecutionStatus {
     /// The stack was updated by another means after this change set was created.
     Obsolete,
 }
-
-forward_display_to_serde!(ExecutionStatus);
-forward_from_str_to_serde!(ExecutionStatus);
 
 /// A parameter set for a change set.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -420,7 +416,7 @@ impl ModifyDetail {
 /// [`Never`]: RequiresRecreation::Never
 /// [`Static`]: Evaluation::Static
 /// [`Dynamic`]: Evaluation::Dynamic
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
 pub enum Replacement {
     /// The resource will be replaced.
     True,
@@ -432,9 +428,6 @@ pub enum Replacement {
     Conditional,
 }
 
-forward_display_to_serde!(Replacement);
-forward_from_str_to_serde!(Replacement);
-
 // The derive for EnumSetType creates an item that triggers this lint, so it has to be disabled
 // at the module level. We don't want to disable it too broadly though, so we wrap its declaration
 // in a module and re-export from that.
@@ -442,8 +435,8 @@ mod modify_scope {
     #![allow(clippy::expl_impl_clone_on_copy)]
 
     /// Indicates which resource attribute is triggering this update.
-    #[derive(Debug, enumset::EnumSetType, serde::Deserialize, serde::Serialize)]
-    #[enumset(no_ops, serialize_as_list)]
+    #[derive(Debug, enumset::EnumSetType, parse_display::Display, parse_display::FromStr)]
+    #[enumset(no_ops)]
     pub enum ModifyScope {
         /// A change to the resource's properties.
         Properties,
@@ -465,9 +458,6 @@ mod modify_scope {
     }
 }
 pub use modify_scope::ModifyScope;
-
-forward_display_to_serde!(ModifyScope);
-forward_from_str_to_serde!(ModifyScope);
 
 /// A change that AWS CloudFormation will make to a resource.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -592,7 +582,7 @@ impl ChangeSource {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
 pub enum Evaluation {
     /// AWS CloudFormation can determine that the target value will change, and its value.
     ///
@@ -610,9 +600,6 @@ pub enum Evaluation {
     /// physical ID, so all references to that resource will also be updated.
     Dynamic,
 }
-
-forward_display_to_serde!(Evaluation);
-forward_from_str_to_serde!(Evaluation);
 
 /// The field that AWS CloudFormation will change, such as the name of a resource's property, and
 /// whether the resource will be recreated.
@@ -703,7 +690,7 @@ impl ResourceTargetDefinition {
 }
 
 /// Indicates whether a change to a property causes the resource to be recreated.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
 pub enum RequiresRecreation {
     /// The resource will not need to be recreated.
     Never,
@@ -717,9 +704,6 @@ pub enum RequiresRecreation {
     /// The resource will need to be recreated.
     Always,
 }
-
-forward_display_to_serde!(RequiresRecreation);
-forward_from_str_to_serde!(RequiresRecreation);
 
 pub(crate) struct ChangeSetWithType {
     pub(crate) change_set: ChangeSet,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,7 @@ pub use apply_stack::{
 pub use delete_stack::{DeleteStack, DeleteStackError, DeleteStackEvents, DeleteStackInput};
 pub use event::{StackEvent, StackEventDetails};
 pub use stack::{StackFailure, StackWarning};
-pub use status::{
-    ChangeSetStatus, InvalidStatus, ResourceStatus, StackStatus, Status, StatusSentiment,
-};
+pub use status::{ChangeSetStatus, ResourceStatus, StackStatus, Status, StatusSentiment};
 pub use tag::Tag;
 
 /// A client for performing cloudformatious operations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod delete_stack;
 mod event;
 mod stack;
 mod status;
+mod tag;
 
 pub mod change_set;
 pub mod status_reason;
@@ -21,6 +22,7 @@ pub use stack::{StackFailure, StackWarning};
 pub use status::{
     ChangeSetStatus, InvalidStatus, ResourceStatus, StackStatus, Status, StatusSentiment,
 };
+pub use tag::Tag;
 
 /// A client for performing cloudformatious operations.
 pub struct Client {

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,10 +1,6 @@
 //! Types and values representing various CloudFormation statuses.
 #![allow(clippy::module_name_repetitions)]
 
-use std::str::FromStr;
-
-use serde_plain::forward_display_to_serde;
-
 /// Common operations for statuses.
 pub trait Status: std::fmt::Debug + std::fmt::Display + private::Sealed {
     /// Indicates whether or not a status is terminal.
@@ -50,13 +46,9 @@ impl StatusSentiment {
     }
 }
 
-/// An error marker returned when trying to parse an invalid status.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct InvalidStatus;
-
 /// Possible change set statuses.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
+#[display(style = "SNAKE_CASE")]
 pub enum ChangeSetStatus {
     CreatePending,
     CreateInProgress,
@@ -91,19 +83,9 @@ impl Status for ChangeSetStatus {
     }
 }
 
-forward_display_to_serde!(ChangeSetStatus);
-
-impl FromStr for ChangeSetStatus {
-    type Err = InvalidStatus;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str(s).map_err(|_| InvalidStatus)
-    }
-}
-
 /// Possible stack statuses.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
+#[display(style = "SNAKE_CASE")]
 pub enum StackStatus {
     CreateInProgress,
     CreateFailed,
@@ -185,19 +167,9 @@ impl Status for StackStatus {
     }
 }
 
-forward_display_to_serde!(StackStatus);
-
-impl FromStr for StackStatus {
-    type Err = InvalidStatus;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str(s).map_err(|_| InvalidStatus)
-    }
-}
-
 /// Possible resource statuses.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, parse_display::Display, parse_display::FromStr)]
+#[display(style = "SNAKE_CASE")]
 pub enum ResourceStatus {
     CreateInProgress,
     CreateFailed,
@@ -261,16 +233,6 @@ impl Status for ResourceStatus {
     }
 }
 
-forward_display_to_serde!(ResourceStatus);
-
-impl FromStr for ResourceStatus {
-    type Err = InvalidStatus;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_plain::from_str(s).map_err(|_| InvalidStatus)
-    }
-}
-
 mod private {
     /// An unreachable trait used to prevent some traits from being implemented outside the crate.
     pub trait Sealed {}
@@ -295,7 +257,7 @@ mod tests {
             "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS".parse(),
             Ok(StackStatus::UpdateRollbackCompleteCleanupInProgress)
         );
-        assert_eq!("oh no".parse::<StackStatus>(), Err(InvalidStatus));
+        assert!("oh no".parse::<StackStatus>().is_err());
     }
 
     #[test]
@@ -309,6 +271,6 @@ mod tests {
             "IMPORT_ROLLBACK_IN_PROGRESS".parse(),
             Ok(ResourceStatus::ImportRollbackInProgress)
         );
-        assert_eq!("oh no".parse::<ResourceStatus>(), Err(InvalidStatus));
+        assert!("oh no".parse::<ResourceStatus>().is_err());
     }
 }

--- a/src/status_reason.rs
+++ b/src/status_reason.rs
@@ -192,7 +192,8 @@ impl<'a> EncodedAuthorizationMessage<'a> {
             .decode_authorization_message()
             .encoded_message(self.0.to_owned())
             .send()
-            .await?;
+            .await
+            .map_err(EncodedAuthorizationMessageDecodeError::from_sdk)?;
         let message = output
             .decoded_message
             .expect("decode authorization message response without decoded_message");
@@ -204,6 +205,12 @@ impl<'a> EncodedAuthorizationMessage<'a> {
 #[derive(Debug)]
 pub struct EncodedAuthorizationMessageDecodeError(Box<dyn std::error::Error>);
 
+impl EncodedAuthorizationMessageDecodeError {
+    fn from_sdk(error: SdkError<DecodeAuthorizationMessageError>) -> Self {
+        Self(error.into())
+    }
+}
+
 impl fmt::Display for EncodedAuthorizationMessageDecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -213,12 +220,6 @@ impl fmt::Display for EncodedAuthorizationMessageDecodeError {
 impl std::error::Error for EncodedAuthorizationMessageDecodeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.0.source()
-    }
-}
-
-impl From<SdkError<DecodeAuthorizationMessageError>> for EncodedAuthorizationMessageDecodeError {
-    fn from(error: SdkError<DecodeAuthorizationMessageError>) -> Self {
-        Self(error.into())
     }
 }
 

--- a/src/status_reason.rs
+++ b/src/status_reason.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use aws_config::SdkConfig;
 use aws_sdk_sts::{error::DecodeAuthorizationMessageError, types::SdkError};
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -186,8 +187,9 @@ impl<'a> EncodedAuthorizationMessage<'a> {
     /// Any errors encountered when invoking the `sts:DecodeAuthorizationMessage` API are returned.
     pub async fn decode(
         &self,
-        sts: &aws_sdk_sts::Client,
+        config: &SdkConfig,
     ) -> Result<serde_json::Value, EncodedAuthorizationMessageDecodeError> {
+        let sts = aws_sdk_sts::Client::new(config);
         let output = sts
             .decode_authorization_message()
             .encoded_message(self.0.to_owned())

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,0 +1,25 @@
+/// A resource tag.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Tag {
+    /// The tag key.
+    pub key: String,
+
+    /// The tag value.
+    pub value: String,
+}
+
+impl Tag {
+    pub(crate) fn from_sdk(tag: aws_sdk_cloudformation::model::Tag) -> Self {
+        Self {
+            key: tag.key.expect("Tag without key"),
+            value: tag.value.expect("Tag without value"),
+        }
+    }
+
+    pub(crate) fn into_sdk(self) -> aws_sdk_cloudformation::model::Tag {
+        aws_sdk_cloudformation::model::Tag::builder()
+            .key(self.key)
+            .value(self.value)
+            .build()
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ Run these tests with `cargo run` from the project root.
 ## Requirements
 
 The integration tests perform actual CloudFormation operations against an actual AWS account, and as such need actual AWS credentials.
-Any mechanism supported by [`rusoto_credential::ChainProvider`](https://docs.rs/rusoto_credential/0.46.0/rusoto_credential/struct.ChainProvider.html) will work.
+Any mechanism supported by [`aws_config::load_from_env`](https://docs.rs/aws-config/latest/aws_config/fn.load_from_env.html) will work.
 
 A CloudFormation template is included to deploy test dependencies: [`cloudformatious-testing.yaml`](cloudformatious-testing.yaml).
 Currently this is just an IAM policy granting CloudFormation permissions.

--- a/tests/it/apply_stack.rs
+++ b/tests/it/apply_stack.rs
@@ -2,8 +2,8 @@ use futures_util::StreamExt;
 
 use cloudformatious::{
     change_set::{Action, ExecutionStatus},
-    ApplyStackError, ApplyStackInput, ChangeSetStatus, CloudFormatious, ResourceStatus,
-    StackFailure, StackStatus, TemplateSource,
+    ApplyStackError, ApplyStackInput, ChangeSetStatus, ResourceStatus, StackFailure, StackStatus,
+    TemplateSource,
 };
 
 use crate::common::{clean_up, generated_name, get_client, EMPTY_TEMPLATE};
@@ -21,21 +21,21 @@ const FAILING_TEMPLATE: &str = r#"
 
 #[tokio::test]
 async fn create_stack_fut_ok() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
     let output = client.apply_stack(input).await?;
     assert_eq!(output.stack_status, StackStatus::CreateComplete);
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_change_set_ok() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
@@ -49,14 +49,14 @@ async fn create_stack_change_set_ok() -> Result<(), Box<dyn std::error::Error>> 
     let output = stack.await?;
     assert_eq!(output.stack_status, StackStatus::CreateComplete);
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_change_set_cancel() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(FAILING_TEMPLATE));
@@ -79,14 +79,14 @@ async fn create_stack_change_set_cancel() -> Result<(), Box<dyn std::error::Erro
         .collect();
     assert_eq!(changes, vec![(&Action::Add, "Vpc", "AWS::EC2::VPC")]);
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_change_set_cancel_idempotent() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
 
@@ -130,14 +130,14 @@ async fn create_stack_change_set_cancel_idempotent() -> Result<(), Box<dyn std::
         .collect();
     assert_eq!(changes, vec![(&Action::Add, "Vpc", "AWS::EC2::VPC")]);
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_stream_ok() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
@@ -164,14 +164,14 @@ async fn create_stack_stream_ok() -> Result<(), Box<dyn std::error::Error>> {
         ]
     );
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_change_set_and_stream_ok() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
@@ -203,14 +203,14 @@ async fn create_stack_change_set_and_stream_ok() -> Result<(), Box<dyn std::erro
         ]
     );
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn apply_overall_idempotent() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
@@ -233,14 +233,14 @@ async fn apply_overall_idempotent() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(output2.stack_status, StackStatus::CreateComplete);
     assert_eq!(output1, output2);
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(FAILING_TEMPLATE));
@@ -272,14 +272,14 @@ async fn create_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error.into());
     }
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_stack_stream_err() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(FAILING_TEMPLATE));
@@ -335,14 +335,14 @@ async fn create_stack_stream_err() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error.into());
     }
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }
 
 #[tokio::test]
 async fn create_change_set_fut_err() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(""));
@@ -357,7 +357,7 @@ async fn create_change_set_fut_err() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn update_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client();
+    let client = get_client().await;
 
     let stack_name = generated_name();
     let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
@@ -393,7 +393,7 @@ async fn update_stack_fut_err() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error.into());
     }
 
-    clean_up(&client, stack_name).await?;
+    clean_up(stack_name).await?;
 
     Ok(())
 }

--- a/tests/it/change_set_detail.rs
+++ b/tests/it/change_set_detail.rs
@@ -1,4 +1,3 @@
-use aws_sdk_cloudformation::model::Tag;
 use enumset::EnumSet;
 
 use cloudformatious::{
@@ -6,7 +5,7 @@ use cloudformatious::{
         Action, Evaluation, ModifyDetail, ModifyScope, Replacement, ResourceChange,
         ResourceChangeDetail, ResourceTargetDefinition,
     },
-    ApplyStackInput, Parameter, TemplateSource,
+    ApplyStackInput, Parameter, Tag, TemplateSource,
 };
 
 use crate::common::{
@@ -31,7 +30,10 @@ async fn changes_tags_only() -> Result<(), Box<dyn std::error::Error>> {
         .expect("missing SubnetId output")
         .value;
 
-    input = input.set_tags([Tag::builder().key("hello").value("world").build()]);
+    input = input.set_tags([Tag {
+        key: "hello".to_string(),
+        value: "world".to_string(),
+    }]);
     let change_set = client.apply_stack(input).change_set().await?;
 
     assert_eq!(

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -1,3 +1,4 @@
+use aws_config::SdkConfig;
 use cloudformatious::Client;
 
 const NAME_PREFIX: &str = "cloudformatious-testing-";
@@ -97,14 +98,13 @@ pub const SECRETS_MANAGER_SECRET: &str = r#"{
     }
 }"#;
 
+pub async fn get_sdk_config() -> SdkConfig {
+    aws_config::load_from_env().await
+}
+
 pub async fn get_client() -> Client {
     let config = aws_config::load_from_env().await;
     Client::new(&config)
-}
-
-pub async fn get_sts_client() -> aws_sdk_sts::Client {
-    let config = aws_config::load_from_env().await;
-    aws_sdk_sts::Client::new(&config)
 }
 
 pub fn generated_name() -> String {

--- a/tests/it/status_reasons.rs
+++ b/tests/it/status_reasons.rs
@@ -6,7 +6,7 @@ use cloudformatious::{
 };
 
 use crate::common::{
-    clean_up, generated_name, get_client, get_sts_client, AUTHORIZATION_FAILURE_TEMPLATE,
+    clean_up, generated_name, get_client, get_sdk_config, AUTHORIZATION_FAILURE_TEMPLATE,
     MISSING_PERMISSION_1_TEMPLATE, MISSING_PERMISSION_2_TEMPLATE,
 };
 
@@ -47,7 +47,8 @@ async fn status_reason_missing_permission_no_principal() -> Result<(), Box<dyn s
 #[tokio::test]
 async fn status_reason_missing_permission_with_principal() -> Result<(), Box<dyn std::error::Error>>
 {
-    let identity_client = get_sts_client().await;
+    let config = get_sdk_config().await;
+    let identity_client = aws_sdk_sts::Client::new(&config);
     let identity = identity_client.get_caller_identity().send().await.unwrap();
 
     let client = get_client().await;
@@ -110,8 +111,8 @@ async fn status_reason_authorization_failure() -> Result<(), Box<dyn std::error:
       Some(StatusReasonDetail::AuthorizationFailure(m)) => m
     );
 
-    let sts_client = get_sts_client().await;
-    let decoded_message = encoded_message.decode(&sts_client).await?;
+    let sdk_config = get_sdk_config().await;
+    let decoded_message = encoded_message.decode(&sdk_config).await?;
     assert_eq!(decoded_message["context"]["action"], "ec2:CreateVpc");
 
     clean_up(stack_name).await?;


### PR DESCRIPTION
- 13f3be8 **test: fix testing of the README.md**

  This presumably worked at some point, but the `rust + no_run` code block
  label is no longer recognised, and instead needs to be `rust,no_run`.

- 4fd2249 **refactor!: switch from rusoto to the official aws-sdk**

  This was a fairly mechanical switch overall (e.g. from `Input` structs
  to builder APIs), but changes to the 'entrypoint' are more significant.
  
  Specifically the aws-sdk does not use a trait for behaviour, and instead
  uses inherent impls on `Client` structs. This meant that using a trait
  for the cloudformatious API became significantly more work since it
  would also need to cover the lower-level APIs needed to drive
  `apply_stack` and `delete_stack`. Furthermore, the trait-based approach
  doesn't really offer anything when the trait is "sealed", and just makes
  calling more awkward.
  
  Follow-up work should try to reduce the surface area of aws-sdk that is
  exposed through the API, and potentially align conventions with the
  aws-sdk in terms of using builders instead of inputs.
  
  BREAKING CHANGE: The `CloudFormatious` trait has been removed, so a
  `rusoto_cloudformation::CloudFormationClient` can no longer be used to
  call cloudformatious APIs. Instead, you should construct a
  `cloudformatious::Client` from an `aws_config::SdkConfig`.
  `EncodedAuthorizationMessage::decode` now needs to be passed an instance
  of `aws_sdk_sts::Client`.

- 9e9f589 **refactor!: remove some aws-sdk types from the public API**

  In particular, `Tag` and `change_set::Parameter` have been created to
  replace `aws_sdk_cloudformation::model::{Tag, Parameter}` in the API. A
  conversion from `aws_sdk_sts::types::SdkError` has also been
  hidden by using an inherent impl conversion method instead of `From`.
  
  BREAKING CHANGE: APIs that previously referenced
  `aws_sdk_cloudformation::model::{Parameter, Tag}` now instead reference
  `change_set::Parameter` and `Tag`, respectively.
  `EncodedAuthorizationMessageDecodeError` no longer implements
  `From<aws_sdk_sts::types::SdkError>`.

- a3b0c01 **refactor!: use `SdkConfig` to decode authorization messages**

  This removes dependence on a specific version of `aws-sdk-sts` from the
  public API.
  
  BREAKING CHANGE: `EncodedAuthorizationMessage::decode` now takes
  `&aws_types::SdkConfig` instead of `&aws_sdk_sts::Client`.

- 9f815ca **refactor!: use `parse-display` instead of `serde`**

  To ensure enum string representations are consistent with their variant
  names we want to derive the string handling (`Display`/`FromStr`). We've
  so far used the somewhat convoluted approach of deriving
  `serde::{Deserialize, Serialize}` and using `serde_plain`'s proc macros
  to generate implementations of `Display` and `FromStr` that forward to
  `serde`, but this puts quite a lot in the public API for each enum that
  we don't really want:
  
  - `serde::Deserialize`
  - `serde::Serialize`
  - `serde_plain::Error`
  
  `parse-display` is another derive macro the specifically generates a
  `Display` and corresponding `FromStr` implementation. It still leaks an
  error type into the API but this is only one thing instead of 3.
  
  BREAKING CHANGE: `Capability`, `ChangeSetStatus`, `ResourceStatus`,
  `StackStatus`, `change_set::Evaluation`, `change_set::ExecutionStatus`,
  `change_set::ModifyScope`, `change_set::Replacement`, and
  `change_set::RequiresRecreation` no longer implement `serde::{Deserialize,
  Serialize}`, and their `FromStr` implementations now use
  `parse_display::ParseError` as the `Err` type.

- 059020d **chore: bump version**

