### PR TITLE
Rename `Status::is_{terminal,settled}`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/src/event.rs
+++ b/src/event.rs
@@ -133,7 +133,7 @@ impl StackEvent {
             resource_status, ..
         } = self
         {
-            resource_status.is_terminal()
+            resource_status.is_settled()
         } else {
             false
         }

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,10 +3,10 @@
 
 /// Common operations for statuses.
 pub trait Status: std::fmt::Debug + std::fmt::Display + private::Sealed {
-    /// Indicates whether or not a status is terminal.
+    /// Indicates whether or not a status is settled.
     ///
-    /// A terminal status is one that won't change again during the current stack operation.
-    fn is_terminal(&self) -> bool;
+    /// A settled status is one that won't change again during the current stack operation.
+    fn is_settled(&self) -> bool;
 
     /// Indicates the sentiment of the status.
     ///
@@ -61,7 +61,7 @@ pub enum ChangeSetStatus {
 }
 
 impl Status for ChangeSetStatus {
-    fn is_terminal(&self) -> bool {
+    fn is_settled(&self) -> bool {
         match self {
             Self::CreatePending
             | Self::CreateInProgress
@@ -112,7 +112,7 @@ pub enum StackStatus {
 }
 
 impl Status for StackStatus {
-    fn is_terminal(&self) -> bool {
+    fn is_settled(&self) -> bool {
         match self {
             Self::CreateInProgress
             | Self::RollbackInProgress
@@ -190,7 +190,7 @@ pub enum ResourceStatus {
 }
 
 impl Status for ResourceStatus {
-    fn is_terminal(&self) -> bool {
+    fn is_settled(&self) -> bool {
         match self {
             Self::CreateInProgress
             | Self::DeleteInProgress


### PR DESCRIPTION
- 4b07082 **refactor!: rename `Status::is_{terminal,settled}`**

  Some statuses really are "terminal", insofar as no operations can be
  performed on the stack other than to delete it. We would like to start
  identifying those statuses, and "terminal" is the best name for them.
  
  A better name for statuses indicating that a stack operation has settled
  is a "settled" status.
  
  BREAKING CHANGE: `Status::is_terminal` has been replaced by
  `Status::is_settled`.

- 22e5076 **chore: bump version**

