### PR TITLE
Handle alternative status reason for a change set with no changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -834,9 +834,9 @@ fn is_already_exists(
 }
 
 fn is_no_changes(status_reason: Option<&str>) -> bool {
-    status_reason
-        .unwrap_or_default()
-        .contains("The submitted information didn't contain changes.")
+    let status_reason = status_reason.unwrap_or_default();
+    status_reason.contains("The submitted information didn't contain changes.")
+        || status_reason.contains("No updates are to be performed.")
 }
 
 fn check_create_progress(stack_status: StackStatus) -> StackOperationStatus {

--- a/tests/cloudformatious-testing.yaml
+++ b/tests/cloudformatious-testing.yaml
@@ -19,6 +19,11 @@ Resources:
               - cloudformation:DescribeStacks
               - cloudformation:ExecuteChangeSet
             Resource: arn:aws:cloudformation:*:*:stack/cloudformatious-testing-*
+          - Sid: TransformOperations
+            Effect: Allow
+            Action:
+              - cloudformation:CreateChangeSet
+            Resource: arn:aws:cloudformation:eu-west-2:aws:transform/Serverless-2016-10-31
           - Sid: CreateSubnet
             Effect: Allow
             Action:

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -15,6 +15,19 @@ pub const EMPTY_TEMPLATE: &str = r#"{
     }
 }"#;
 
+pub const EMPTY_TEMPLATE_WITH_TRANSFORM: &str = r#"{
+    "Transform": "AWS::Serverless-2016-10-31",
+    "Conditions": {
+        "Never": { "Fn::Equals": [true, false] }
+    },
+    "Resources": {
+        "Fake": {
+            "Type": "Custom::Fake",
+            "Condition": Never
+        }
+    }
+}"#;
+
 pub const NON_EMPTY_TEMPLATE: &str = r#"{
     "Parameters": {
         "CidrBlock": {


### PR DESCRIPTION
Fixes #15.

---

- b8930b2 **fix: handle alternative status reason for a change set with no changes**

  The change set status reason can sometimes be "The submitted information
  didn't contain changes." and other times "No updates are to be
  performed.". This might be related to transforms such as
  `AWS::Serverless-2016-10-31` since it was encountered with a template
  using it.

- 2d89041 **chore: bump version**

