### PR TITLE
Add `BlockedStackStatus`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4.19"
 enumset = "1.0.6"
 futures-util = "0.3.14"
 lazy_static = "1.4.0"
-parse-display = { version = "0.6.0", default-features = false }
+parse-display = "0.6.0"
 regex = "1.5.4"
 serde_json = "1.0.85"
 tokio = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@ pub use apply_stack::{
 pub use delete_stack::{DeleteStack, DeleteStackError, DeleteStackEvents, DeleteStackInput};
 pub use event::{StackEvent, StackEventDetails};
 pub use stack::{StackFailure, StackWarning};
-pub use status::{ChangeSetStatus, ResourceStatus, StackStatus, Status, StatusSentiment};
+pub use status::{
+    BlockedStackStatus, ChangeSetStatus, ResourceStatus, StackStatus, Status, StatusSentiment,
+};
 pub use tag::Tag;
 
 /// A client for performing cloudformatious operations.

--- a/src/status.rs
+++ b/src/status.rs
@@ -99,6 +99,7 @@ pub enum StackStatus {
     UpdateInProgress,
     UpdateCompleteCleanupInProgress,
     UpdateComplete,
+    UpdateFailed,
     UpdateRollbackInProgress,
     UpdateRollbackFailed,
     UpdateRollbackCompleteCleanupInProgress,
@@ -131,6 +132,7 @@ impl Status for StackStatus {
             | Self::DeleteFailed
             | Self::DeleteComplete
             | Self::UpdateComplete
+            | Self::UpdateFailed
             | Self::UpdateRollbackFailed
             | Self::UpdateRollbackComplete
             | Self::ImportComplete
@@ -156,6 +158,7 @@ impl Status for StackStatus {
             | Self::RollbackFailed
             | Self::RollbackComplete
             | Self::DeleteFailed
+            | Self::UpdateFailed
             | Self::UpdateRollbackInProgress
             | Self::UpdateRollbackFailed
             | Self::UpdateRollbackCompleteCleanupInProgress

--- a/tests/cloudformatious-testing.yaml
+++ b/tests/cloudformatious-testing.yaml
@@ -52,11 +52,20 @@ Resources:
               - secretsmanager:DeleteSecret
               - secretsmanager:TagResource
             Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:cloudformatious-testing-*
+          - Sid: UseRoles
+            Effect: Allow
+            Action: iam:PassRole
+            Resource:
+              - !GetAtt Testing.Arn
+              - !GetAtt DenyDeleteSubnet.Arn
           - Sid: DecodeAuthorizationMessage
             Effect: Allow
             Action:
               - sts:DecodeAuthorizationMessage
             Resource: '*'
+      Roles:
+        - !Ref Testing
+        - !Ref DenyDeleteSubnet
 
   Vpc:
     Type: AWS::EC2::VPC
@@ -65,6 +74,40 @@ Resources:
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName
+
+  Testing:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: cloudformation.amazonaws.com
+      RoleName: cloudformatious-testing
+
+  DenyDeleteSubnet:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: cloudformation.amazonaws.com
+      Policies:
+        - PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: DenyDeleteSubnet
+                Effect: Deny
+                Action:
+                  - ec2:DeleteSubnet
+                Resource: '*'
+          PolicyName: DenyDeleteSubnet
+      RoleName: cloudformatious-testing-deny-delete-subnet
 
 Outputs:
   PolicyArn:

--- a/tests/it/blocked_stack.rs
+++ b/tests/it/blocked_stack.rs
@@ -1,0 +1,46 @@
+use crate::common::{clean_up, stack_with_status};
+
+#[tokio::test]
+async fn create_failed() -> Result<(), Box<dyn std::error::Error>> {
+    let failure = stack_with_status::create_failed().await;
+
+    clean_up(failure.stack_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
+    let failure = stack_with_status::rollback_failed().await;
+
+    clean_up(failure.stack_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_failed() -> Result<(), Box<dyn std::error::Error>> {
+    let failure = stack_with_status::delete_failed().await;
+
+    clean_up(failure.stack_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_failed() -> Result<(), Box<dyn std::error::Error>> {
+    let failure = stack_with_status::update_failed().await;
+
+    clean_up(failure.stack_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
+    let failure = stack_with_status::update_rollback_failed().await;
+
+    clean_up(failure.stack_id).await?;
+
+    Ok(())
+}

--- a/tests/it/blocked_stack.rs
+++ b/tests/it/blocked_stack.rs
@@ -1,8 +1,9 @@
 use std::convert::TryFrom;
 
-use cloudformatious::BlockedStackStatus;
+use assert_matches::assert_matches;
+use cloudformatious::{ApplyStackError, ApplyStackInput, BlockedStackStatus, Client, Parameter};
 
-use crate::common::{clean_up, get_client, stack_with_status};
+use crate::common::{clean_up, get_client, stack_with_status, NON_EMPTY_TEMPLATE};
 
 #[tokio::test]
 async fn create_failed() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,6 +12,14 @@ async fn create_failed() -> Result<(), Box<dyn std::error::Error>> {
 
     let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
     assert_eq!(status, BlockedStackStatus::CreateFailed);
+
+    let error = try_update(&client, &failure.stack_id).await;
+    assert_matches!(
+        error,
+        ApplyStackError::Blocked {
+            status: BlockedStackStatus::CreateFailed,
+        }
+    );
 
     clean_up(failure.stack_id).await?;
 
@@ -25,6 +34,14 @@ async fn rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
     let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
     assert_eq!(status, BlockedStackStatus::RollbackFailed);
 
+    let error = try_update(&client, &failure.stack_id).await;
+    assert_matches!(
+        error,
+        ApplyStackError::Blocked {
+            status: BlockedStackStatus::RollbackFailed,
+        }
+    );
+
     clean_up(failure.stack_id).await?;
 
     Ok(())
@@ -37,6 +54,14 @@ async fn delete_failed() -> Result<(), Box<dyn std::error::Error>> {
 
     let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
     assert_eq!(status, BlockedStackStatus::DeleteFailed);
+
+    let error = try_update(&client, &failure.stack_id).await;
+    assert_matches!(
+        error,
+        ApplyStackError::Blocked {
+            status: BlockedStackStatus::DeleteFailed,
+        }
+    );
 
     clean_up(failure.stack_id).await?;
 
@@ -51,6 +76,14 @@ async fn update_failed() -> Result<(), Box<dyn std::error::Error>> {
     let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
     assert_eq!(status, BlockedStackStatus::UpdateFailed);
 
+    let error = try_update(&client, &failure.stack_id).await;
+    assert_matches!(
+        error,
+        ApplyStackError::Blocked {
+            status: BlockedStackStatus::UpdateFailed,
+        }
+    );
+
     clean_up(failure.stack_id).await?;
 
     Ok(())
@@ -64,7 +97,31 @@ async fn update_rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
     let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
     assert_eq!(status, BlockedStackStatus::UpdateRollbackFailed);
 
+    let error = try_update(&client, &failure.stack_id).await;
+    assert_matches!(
+        error,
+        ApplyStackError::Blocked {
+            status: BlockedStackStatus::UpdateRollbackFailed,
+        }
+    );
+
     clean_up(failure.stack_id).await?;
 
     Ok(())
+}
+
+async fn try_update(client: &Client, stack_name: &str) -> ApplyStackError {
+    client
+        .apply_stack(
+            ApplyStackInput::new(
+                stack_name,
+                cloudformatious::TemplateSource::inline(NON_EMPTY_TEMPLATE),
+            )
+            .set_parameters([Parameter {
+                key: "CidrBlock".to_string(),
+                value: "10.0.0.0/28".to_string(),
+            }]),
+        )
+        .await
+        .unwrap_err()
 }

--- a/tests/it/blocked_stack.rs
+++ b/tests/it/blocked_stack.rs
@@ -1,8 +1,16 @@
-use crate::common::{clean_up, stack_with_status};
+use std::convert::TryFrom;
+
+use cloudformatious::BlockedStackStatus;
+
+use crate::common::{clean_up, get_client, stack_with_status};
 
 #[tokio::test]
 async fn create_failed() -> Result<(), Box<dyn std::error::Error>> {
-    let failure = stack_with_status::create_failed().await;
+    let client = get_client().await;
+    let failure = stack_with_status::create_failed(&client).await;
+
+    let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
+    assert_eq!(status, BlockedStackStatus::CreateFailed);
 
     clean_up(failure.stack_id).await?;
 
@@ -11,7 +19,11 @@ async fn create_failed() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
-    let failure = stack_with_status::rollback_failed().await;
+    let client = get_client().await;
+    let failure = stack_with_status::rollback_failed(&client).await;
+
+    let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
+    assert_eq!(status, BlockedStackStatus::RollbackFailed);
 
     clean_up(failure.stack_id).await?;
 
@@ -20,7 +32,11 @@ async fn rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn delete_failed() -> Result<(), Box<dyn std::error::Error>> {
-    let failure = stack_with_status::delete_failed().await;
+    let client = get_client().await;
+    let failure = stack_with_status::delete_failed(&client).await;
+
+    let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
+    assert_eq!(status, BlockedStackStatus::DeleteFailed);
 
     clean_up(failure.stack_id).await?;
 
@@ -29,7 +45,11 @@ async fn delete_failed() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn update_failed() -> Result<(), Box<dyn std::error::Error>> {
-    let failure = stack_with_status::update_failed().await;
+    let client = get_client().await;
+    let failure = stack_with_status::update_failed(&client).await;
+
+    let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
+    assert_eq!(status, BlockedStackStatus::UpdateFailed);
 
     clean_up(failure.stack_id).await?;
 
@@ -38,7 +58,11 @@ async fn update_failed() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn update_rollback_failed() -> Result<(), Box<dyn std::error::Error>> {
-    let failure = stack_with_status::update_rollback_failed().await;
+    let client = get_client().await;
+    let failure = stack_with_status::update_rollback_failed(&client).await;
+
+    let status = BlockedStackStatus::try_from(failure.stack_status).unwrap();
+    assert_eq!(status, BlockedStackStatus::UpdateRollbackFailed);
 
     clean_up(failure.stack_id).await?;
 

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -39,12 +39,6 @@ pub const NON_EMPTY_TEMPLATE: &str = r#"{
             "Type": "AWS::EC2::Subnet",
             "Properties": {
                 "CidrBlock": {"Ref": "CidrBlock"},
-                "Tags": [
-                    {
-                        "Key": "VpcId",
-                        "Value": {"Fn::ImportValue": "cloudformatious-testing-VpcId"}
-                    }
-                ],
                 "VpcId": {"Fn::ImportValue": "cloudformatious-testing-VpcId"}
             }
         }

--- a/tests/it/common/stack_with_status.rs
+++ b/tests/it/common/stack_with_status.rs
@@ -1,12 +1,12 @@
 use assert_matches::assert_matches;
 use cloudformatious::{
-    ApplyStackError, ApplyStackInput, DeleteStackError, DeleteStackInput, Parameter, StackFailure,
-    StackStatus, TemplateSource,
+    ApplyStackError, ApplyStackInput, Client, DeleteStackError, DeleteStackInput, Parameter,
+    StackFailure, StackStatus, TemplateSource,
 };
 
 use crate::common::{get_role_arn, TestingRole, EMPTY_TEMPLATE};
 
-use super::{generated_name, get_client, NON_EMPTY_TEMPLATE};
+use super::{generated_name, NON_EMPTY_TEMPLATE};
 
 const FAILING_TEMPLATE: &str = r#"{
     "Resources": {
@@ -46,8 +46,7 @@ pub const ROLLBACK_FAILING_TEMPLATE: &str = r#"{
     }
 }"#;
 
-pub async fn create_failed() -> StackFailure {
-    let client = get_client().await;
+pub async fn create_failed(client: &Client) -> StackFailure {
     let error = client
         .apply_stack(
             ApplyStackInput::new(generated_name(), TemplateSource::inline(FAILING_TEMPLATE))
@@ -60,8 +59,7 @@ pub async fn create_failed() -> StackFailure {
     failure
 }
 
-pub async fn rollback_failed() -> StackFailure {
-    let client = get_client().await;
+pub async fn rollback_failed(client: &Client) -> StackFailure {
     let error = client
         .apply_stack(
             ApplyStackInput::new(
@@ -81,8 +79,7 @@ pub async fn rollback_failed() -> StackFailure {
     failure
 }
 
-pub async fn delete_failed() -> StackFailure {
-    let client = get_client().await;
+pub async fn delete_failed(client: &Client) -> StackFailure {
     let output = client
         .apply_stack(
             ApplyStackInput::new(generated_name(), TemplateSource::inline(NON_EMPTY_TEMPLATE))
@@ -106,8 +103,7 @@ pub async fn delete_failed() -> StackFailure {
     failure
 }
 
-pub async fn update_failed() -> StackFailure {
-    let client = get_client().await;
+pub async fn update_failed(client: &Client) -> StackFailure {
     let output = client
         .apply_stack(ApplyStackInput::new(
             generated_name(),
@@ -129,8 +125,7 @@ pub async fn update_failed() -> StackFailure {
     failure
 }
 
-pub async fn update_rollback_failed() -> StackFailure {
-    let client = get_client().await;
+pub async fn update_rollback_failed(client: &Client) -> StackFailure {
     let output = client
         .apply_stack(
             ApplyStackInput::new(generated_name(), TemplateSource::inline(NON_EMPTY_TEMPLATE))

--- a/tests/it/common/stack_with_status.rs
+++ b/tests/it/common/stack_with_status.rs
@@ -1,0 +1,162 @@
+use assert_matches::assert_matches;
+use cloudformatious::{
+    ApplyStackError, ApplyStackInput, DeleteStackError, DeleteStackInput, Parameter, StackFailure,
+    StackStatus, TemplateSource,
+};
+
+use crate::common::{get_role_arn, TestingRole, EMPTY_TEMPLATE};
+
+use super::{generated_name, get_client, NON_EMPTY_TEMPLATE};
+
+const FAILING_TEMPLATE: &str = r#"{
+    "Resources": {
+        "Bucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {}
+        }
+    }
+
+}"#;
+
+pub const ROLLBACK_FAILING_TEMPLATE: &str = r#"{
+    "Parameters": {
+        "CidrBlock": {
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "Subnet": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "CidrBlock": {"Ref": "CidrBlock"},
+                "Tags": [
+                    {
+                        "Key": "Foo",
+                        "Value": "Bar"
+                    }
+                ],
+                "VpcId": {"Fn::ImportValue": "cloudformatious-testing-VpcId"}
+            }
+        },
+        "Bucket": {
+            "Type": "AWS::S3::Bucket",
+            "DependsOn": ["Subnet"],
+            "Properties": {}
+        }
+    }
+}"#;
+
+pub async fn create_failed() -> StackFailure {
+    let client = get_client().await;
+    let error = client
+        .apply_stack(
+            ApplyStackInput::new(generated_name(), TemplateSource::inline(FAILING_TEMPLATE))
+                .set_disable_rollback(true),
+        )
+        .await
+        .unwrap_err();
+    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::CreateFailed);
+    failure
+}
+
+pub async fn rollback_failed() -> StackFailure {
+    let client = get_client().await;
+    let error = client
+        .apply_stack(
+            ApplyStackInput::new(
+                generated_name(),
+                TemplateSource::inline(ROLLBACK_FAILING_TEMPLATE),
+            )
+            .set_parameters([Parameter {
+                key: "CidrBlock".to_string(),
+                value: "10.0.0.32/28".to_string(),
+            }])
+            .set_role_arn(get_role_arn(TestingRole::DenyDeleteSubnet).await),
+        )
+        .await
+        .unwrap_err();
+    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::RollbackFailed);
+    failure
+}
+
+pub async fn delete_failed() -> StackFailure {
+    let client = get_client().await;
+    let output = client
+        .apply_stack(
+            ApplyStackInput::new(generated_name(), TemplateSource::inline(NON_EMPTY_TEMPLATE))
+                .set_parameters([Parameter {
+                    key: "CidrBlock".to_string(),
+                    value: "10.0.0.48/28".to_string(),
+                }]),
+        )
+        .await
+        .unwrap();
+
+    let error = client
+        .delete_stack(
+            DeleteStackInput::new(&output.stack_id)
+                .set_role_arn(get_role_arn(TestingRole::DenyDeleteSubnet).await),
+        )
+        .await
+        .unwrap_err();
+    let failure = assert_matches!(error, DeleteStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::DeleteFailed);
+    failure
+}
+
+pub async fn update_failed() -> StackFailure {
+    let client = get_client().await;
+    let output = client
+        .apply_stack(ApplyStackInput::new(
+            generated_name(),
+            TemplateSource::inline(EMPTY_TEMPLATE),
+        ))
+        .await
+        .unwrap();
+
+    let error = client
+        .apply_stack(
+            ApplyStackInput::new(output.stack_id, TemplateSource::inline(FAILING_TEMPLATE))
+                .set_disable_rollback(true),
+        )
+        .await
+        .unwrap_err();
+
+    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::UpdateFailed);
+    failure
+}
+
+pub async fn update_rollback_failed() -> StackFailure {
+    let client = get_client().await;
+    let output = client
+        .apply_stack(
+            ApplyStackInput::new(generated_name(), TemplateSource::inline(NON_EMPTY_TEMPLATE))
+                .set_parameters([Parameter {
+                    key: "CidrBlock".to_string(),
+                    value: "10.0.0.80/28".to_string(),
+                }]),
+        )
+        .await
+        .unwrap();
+
+    let error = client
+        .apply_stack(
+            ApplyStackInput::new(
+                output.stack_id,
+                TemplateSource::inline(ROLLBACK_FAILING_TEMPLATE),
+            )
+            .set_parameters([Parameter {
+                key: "CidrBlock".to_string(),
+                value: "10.0.0.80/28".to_string(),
+            }]),
+        )
+        .await
+        .unwrap_err();
+
+    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::UpdateRollbackFailed);
+    failure
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod apply_stack;
+mod blocked_stack;
 mod change_set_detail;
 mod common;
 mod delete_stack;


### PR DESCRIPTION
- 01069a3 **fix: enable default features on `parse_display`**

  Without the `std` feature, `parse_display::ParseError` doesn't implement
  `std::error::Error`, which is not OK for an error type in the public
  API. The `std` feature is the only default feature on `parse_display` so
  it makes sense to just re-enable default features.

- 536ec22 **feat!: add `disable_rollback` option to `ApplyStackInput`**

  This reflects an option available when updating a stack or executing a
  change set directly.
  
  BREAKING CHANGE: A `disable_rollback` field has been added to
  `ApplyStackInput`, which is an exhaustive structure.

- 2dd3ef5 **chore: remove unnecessary `Tags` from non-empty test template**

  This was intended to limit which subnets could be managed by the
  cloudformatious testing policy, however this is now achieved by
  conditions on the VPC.

- 277ae1d **test: add test machinery for reaching blocked stack statuses**

  This requires some additional roles and templates. The roles do not
  meaningfully increase the access required by the tests since they are
  restricted to the same permissions (or less).

- 7bcf7a0 **feat: add `BlockedStackStatus` enum**

  A `BlockedStackStatus` can be 'parsed' from a regular `StackStatus`
  via the `TryFrom` implementation. It could be used to more precisely
  deal with the possible causes for a stack to be blocked.

- 0a54d2a **feat!: add `ApplyStackError::Blocked` variant**

  Attempting to perform an `apply_stack` operation on a stack in a blocked
  status will now cause an `ApplyStackError::Blocked { .. }` error to be
  returned. This offers direct access to the `BlockedStackStatus`, making
  it easier to implement appropriate handling, if desired.
  
  BREAKING CHANGE: A `Blocked` variant has been added to the
  `ApplyStackError` enum, which is exhaustive.

- 7b0a752 **chore: bump version**

