### PR TITLE
Add `ROLLBACK_COMPLETE` as a blocked stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudformatious"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2018"

--- a/src/status.rs
+++ b/src/status.rs
@@ -180,6 +180,7 @@ impl Status for StackStatus {
 #[display(style = "SNAKE_CASE")]
 pub enum BlockedStackStatus {
     CreateFailed,
+    RollbackComplete,
     RollbackFailed,
     DeleteFailed,
     UpdateFailed,
@@ -192,6 +193,7 @@ impl TryFrom<StackStatus> for BlockedStackStatus {
     fn try_from(status: StackStatus) -> Result<Self, Self::Error> {
         match status {
             StackStatus::CreateFailed => Ok(Self::CreateFailed),
+            StackStatus::RollbackComplete => Ok(Self::RollbackComplete),
             StackStatus::RollbackFailed => Ok(Self::RollbackFailed),
             StackStatus::DeleteFailed => Ok(Self::DeleteFailed),
             StackStatus::UpdateFailed => Ok(Self::UpdateFailed),
@@ -202,7 +204,6 @@ impl TryFrom<StackStatus> for BlockedStackStatus {
             | StackStatus::DeleteInProgress
             | StackStatus::ReviewInProgress
             | StackStatus::RollbackInProgress
-            | StackStatus::RollbackComplete
             | StackStatus::UpdateInProgress
             | StackStatus::UpdateCompleteCleanupInProgress
             | StackStatus::UpdateComplete

--- a/tests/it/common/stack_with_status.rs
+++ b/tests/it/common/stack_with_status.rs
@@ -59,6 +59,19 @@ pub async fn create_failed(client: &Client) -> StackFailure {
     failure
 }
 
+pub async fn rollback_complete(client: &Client) -> StackFailure {
+    let error = client
+        .apply_stack(ApplyStackInput::new(
+            generated_name(),
+            TemplateSource::inline(FAILING_TEMPLATE),
+        ))
+        .await
+        .unwrap_err();
+    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
+    assert_eq!(failure.stack_status, StackStatus::RollbackComplete);
+    failure
+}
+
 pub async fn rollback_failed(client: &Client) -> StackFailure {
     let error = client
         .apply_stack(


### PR DESCRIPTION
- 6745355 **feat!: add `ROLLBACK_COMPLETE` as a blocked stack**

  Stacks in `ROLLBACK_COMPLETE` also cannot be updated – rollback must be
  continued and/or the stack delete.
  
  BREAKING CHANGE: A new `RollbackComplete` variant has been added to the
  `BlockedStackStatus` enum, which is non-exhaustive.

- 4a1611d **chore: bump version**

