### PR TITLE
Fix `UPDATE_ROLLBACK_COMPLETE` bug

### DIFF
--- a/tests/cloudformatious-testing.yaml
+++ b/tests/cloudformatious-testing.yaml
@@ -23,7 +23,7 @@ Resources:
             Effect: Allow
             Action:
               - cloudformation:CreateChangeSet
-            Resource: arn:aws:cloudformation:eu-west-2:aws:transform/Serverless-2016-10-31
+            Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
           - Sid: CreateSubnet
             Effect: Allow
             Action:


### PR DESCRIPTION
- 19eaacf **fix: avoid panicking if `change_set_id` isn't available on stack**

  For reasons unknown, CloudFormation stacks lose their `change_set_id` if
  a no-op change set is created against a stack in the
  `UPDATE_ROLLBACK_COMPLETE` state. This was causing a panic, since we
  assumed the field would always be set. This assumption was based on the
  fact that we must have successfully created a change set before we would
  call `describe_output` (even if the change set reaches a failing
  terminal status, it would still have an ID). As a simple and direct fix,
  we now simply pass the change set ID along to `describe_output`.
  
  This could technically be considered a breaking change, since it changes
  the reported `change_set_id` on no-op updates to stacks *not* in the
  `UPDATE_ROLLBACK_COMPLETE` state. However, we could argue that the
  original intent was for the `ApplyStackOutput` to include the ID of the
  change set that was created for the operation, and that the previous
  behaviour for no-up updates was a bug (and indeed we argue this, and so
  don't consider this a breaking change...).
  
  Fixes #11.

- a1b2f06 **fix: parameterise region in serverless transform permission**

  This allows the tests to operate in non-`eu-west-2` regions.
