### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/connec/cloudformatious"
 
 [dependencies]
 async-stream = "0.3.0"
-aws-config = "0.49.0"
-aws-sdk-cloudformation = "0.19.0"
-aws-sdk-sts = "0.19.0"
-aws-smithy-types-convert = { version = "0.49.0", features = ["convert-chrono"] }
+aws-config = "0.55.3"
+aws-sdk-cloudformation = "0.28.0"
+aws-sdk-sts = "0.28.0"
+aws-smithy-types-convert = { version = "0.55.3", features = ["convert-chrono"] }
 chrono = "0.4.19"
 enumset = "1.0.6"
 futures-util = "0.3.14"

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -603,13 +603,12 @@ impl fmt::Display for ApplyStackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CloudFormationApi(error) => {
-                write!(f, "CloudFormation API error: {}", error)
+                write!(f, "CloudFormation API error: {error}")
             }
             Self::Blocked { status } => {
                 write!(
                     f,
-                    "stack operation failed because the stack is in a blocked state: {}",
-                    status
+                    "stack operation failed because the stack is in a blocked state: {status}",
                 )
             }
             Self::CreateChangeSetFailed {
@@ -619,12 +618,11 @@ impl fmt::Display for ApplyStackError {
             } => {
                 write!(
                     f,
-                    "Change set {} failed to create; terminal status: {} ({})",
-                    id, status, status_reason
+                    "Change set {id} failed to create; terminal status: {status} ({status_reason})",
                 )
             }
-            Self::Failure(failure) => write!(f, "{}", failure),
-            Self::Warning { warning, .. } => write!(f, "{}", warning),
+            Self::Failure(failure) => write!(f, "{failure}"),
+            Self::Warning { warning, .. } => write!(f, "{warning}"),
         }
     }
 }

--- a/src/delete_stack.rs
+++ b/src/delete_stack.rs
@@ -163,10 +163,10 @@ impl fmt::Display for DeleteStackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CloudFormationApi(error) => {
-                write!(f, "CloudFormation API error: {}", error)
+                write!(f, "CloudFormation API error: {error}")
             }
-            Self::Failure(failure) => write!(f, "{}", failure),
-            Self::Warning(warning) => write!(f, "{}", warning),
+            Self::Failure(failure) => write!(f, "{failure}"),
+            Self::Warning(warning) => write!(f, "{warning}"),
         }
     }
 }
@@ -195,9 +195,8 @@ impl<'client> DeleteStack<'client> {
         input: DeleteStackInput,
     ) -> Self {
         let event_stream = try_stream! {
-            let stack_id = match describe_stack_id(client, input.stack_name.clone()).await? {
-                Some(stack_id) => stack_id,
-                None => return,
+            let Some(stack_id) = (describe_stack_id(client, input.stack_name.clone()).await?) else {
+                return;
             };
 
             let started_at = Utc::now();

--- a/src/event.rs
+++ b/src/event.rs
@@ -139,7 +139,7 @@ impl StackEvent {
         }
     }
 
-    pub(crate) fn from_sdk(event: aws_sdk_cloudformation::model::StackEvent) -> Self {
+    pub(crate) fn from_sdk(event: aws_sdk_cloudformation::types::StackEvent) -> Self {
         let is_stack = event.physical_resource_id.as_deref() == event.stack_id.as_deref();
         let resource_status = event
             .resource_status
@@ -160,7 +160,8 @@ impl StackEvent {
             timestamp: event
                 .timestamp
                 .expect("StackEvent without timestamp")
-                .to_chrono_utc(),
+                .to_chrono_utc()
+                .expect("invalid timestamp"),
         };
         if is_stack {
             Self::Stack {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,7 +1,9 @@
 use std::{fmt, pin::Pin, task, time::Duration};
 
 use async_stream::try_stream;
-use aws_sdk_cloudformation::{error::DescribeStackEventsError, types::SdkError};
+use aws_sdk_cloudformation::{
+    error::SdkError, operation::describe_stack_events::DescribeStackEventsError,
+};
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use chrono::{DateTime, Utc};
 use futures_util::Stream;
@@ -178,6 +180,7 @@ where
                             .timestamp
                             .expect("StackEvent without timestamp")
                             .to_chrono_utc()
+                            .expect("invalid timestamp")
                             > since
                     })
                     .map(StackEvent::from_sdk)

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -184,7 +184,7 @@ where
                     .collect();
 
                 if let Some(stack_event) = stack_events.first() {
-                    since = stack_event.timestamp().clone();
+                    since = *stack_event.timestamp();
                 }
 
                 for stack_event in stack_events.into_iter().rev() {

--- a/src/status_reason.rs
+++ b/src/status_reason.rs
@@ -3,7 +3,9 @@
 use std::fmt;
 
 use aws_config::SdkConfig;
-use aws_sdk_sts::{error::DecodeAuthorizationMessageError, types::SdkError};
+use aws_sdk_sts::{
+    error::SdkError, operation::decode_authorization_message::DecodeAuthorizationMessageError,
+};
 use lazy_static::lazy_static;
 use regex::Regex;
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -9,15 +9,15 @@ pub struct Tag {
 }
 
 impl Tag {
-    pub(crate) fn from_sdk(tag: aws_sdk_cloudformation::model::Tag) -> Self {
+    pub(crate) fn from_sdk(tag: aws_sdk_cloudformation::types::Tag) -> Self {
         Self {
             key: tag.key.expect("Tag without key"),
             value: tag.value.expect("Tag without value"),
         }
     }
 
-    pub(crate) fn into_sdk(self) -> aws_sdk_cloudformation::model::Tag {
-        aws_sdk_cloudformation::model::Tag::builder()
+    pub(crate) fn into_sdk(self) -> aws_sdk_cloudformation::types::Tag {
+        aws_sdk_cloudformation::types::Tag::builder()
             .key(self.key)
             .value(self.value)
             .build()

--- a/tests/it/change_set_detail.rs
+++ b/tests/it/change_set_detail.rs
@@ -88,9 +88,10 @@ async fn secrets_manager_secret_tags_only() -> Result<(), Box<dyn std::error::Er
         .flatten()
         .collect();
     assert!(!targets.is_empty());
-    assert!(targets
-        .iter()
-        .all(|target| matches!(target, ResourceTargetDefinition::Tags)));
+    assert!(targets.iter().all(|target| matches!(
+        target,
+        ResourceTargetDefinition::Properties { name, .. } if name == "Tags"
+    )));
 
     clean_up(stack_name).await?;
 

--- a/tests/it/delete_stack.rs
+++ b/tests/it/delete_stack.rs
@@ -1,4 +1,4 @@
-use aws_sdk_cloudformation::model::StackStatus;
+use aws_sdk_cloudformation::types::StackStatus;
 use futures_util::StreamExt;
 
 use cloudformatious::{ApplyStackInput, DeleteStackInput, Parameter, TemplateSource};


### PR DESCRIPTION
- 323e3f8 **chore: fix new clippy issues**

  These fix new clippy rules and lint introduces by dependency updates.

- 3e2f881 **chore!: upgrade aws-sdk crates**

  BREAKING CHANGE: The `aws-types` crate appears in the public API, so
  upgrading it is a breaking change.

- ff99989 **chore: update test to handle CloudFormation API change**

  The CloudFormation API now reports tag-only changes to
  `AWS::SecretsManager::Secret` with
  `ResourceTargetDefinition::Properties`.
