### PR TITLE
Upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/connec/cloudformatious"
 
 [dependencies]
 async-stream = "0.3.0"
-aws-config = "0.55.3"
-aws-sdk-cloudformation = "0.28.0"
-aws-sdk-sts = "0.28.0"
-aws-smithy-types-convert = { version = "0.55.3", features = ["convert-chrono"] }
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-cloudformation = "1"
+aws-sdk-sts = "1"
+aws-smithy-types-convert = { version = "0.60.8", features = ["convert-chrono"] }
 chrono = "0.4.19"
 enumset = "1.0.6"
 futures-util = "0.3.14"

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -260,7 +260,7 @@ impl ApplyStackInput {
             ))
             .change_set_name(format!("apply-stack-{}", Utc::now().timestamp_millis()))
             .change_set_type(change_set_type.into_sdk())
-            .set_notification_ar_ns(Some(self.notification_arns))
+            .set_notification_arns(Some(self.notification_arns))
             .set_parameters(Some(
                 self.parameters
                     .into_iter()

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -712,7 +712,7 @@ impl<'client> ApplyStack<'client> {
                     Err(ApplyStackError::Failure(failure))?;
                     unreachable!()
                 }
-                Ok(_) => None,
+                Ok(()) => None,
                 Err(StackOperationError::Warning(warning)) => Some(warning),
             };
 

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -895,9 +895,7 @@ fn is_execute_blocked(
 }
 
 fn is_blocked(pattern: &Regex, message: &str) -> Option<BlockedStackStatus> {
-    let Some(detail) = pattern.captures(message) else {
-        return None;
-    };
+    let detail = pattern.captures(message)?;
 
     let status: StackStatus = detail
         .name("status")

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -148,7 +148,7 @@ impl ChangeSet {
                 .as_str()
                 .parse()
                 .expect("DescribeChangeSetOutput with invalid execution_status"),
-            notification_arns: change_set.notification_ar_ns.unwrap_or_default(),
+            notification_arns: change_set.notification_arns.unwrap_or_default(),
             parameters: change_set
                 .parameters
                 .unwrap_or_default()

--- a/src/status_reason.rs
+++ b/src/status_reason.rs
@@ -187,6 +187,12 @@ impl<'a> EncodedAuthorizationMessage<'a> {
     /// # Errors
     ///
     /// Any errors encountered when invoking the `sts:DecodeAuthorizationMessage` API are returned.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the `sts:DecodeAuthorizationMessage` API does not repond with a decoded
+    /// message (this is allowed by AWS SDK types but should never happen per the semantics of the
+    /// API).
     pub async fn decode(
         &self,
         config: &SdkConfig,
@@ -262,13 +268,13 @@ mod tests {
     fn status_reason_detail() {
         #![allow(clippy::shadow_unrelated)]
 
-        let example = r#"Resource creation cancelled"#;
+        let example = r"Resource creation cancelled";
         assert_eq!(
             StatusReasonDetail::new(example),
             Some(StatusReasonDetail::CreationCancelled)
         );
 
-        let example = r#"API: ec2:ModifyVpcAttribute You are not authorized to perform this operation. Encoded authorization failure message: g1-YvnBabE1x9q868e9rU4VX9gFjPpt31dEvX6uYDMWmdkou9pGLq85c3Wy4IAr3CwKrF8Jqu0aIkiy0TBM5SU22pSjE-gzZuP1dg5rvyhI1fl5DBB4DiDyRmZpOjovE2w0MMxuM4QFqf6zAtlbCtwdCYVxHwTpKrlkQAJEr40twnTPWe1_Vh-YRfprV9RBis8nReUcf87GV1oGFxjLujid4oOAinD-NmpIUR5VLCw2ycoOZihPR_unBC9stRioVeYiBg-Q1T5IU-J-xEQK092YuR-H4vqMm5Nwg4l1kN10t8pbFb_YopmILVfvh-ViLBbzE0cO6ZlvLvcMcB8crsbgLP10H05hPtHDIGUMwc_xM-y_9SUAcrVUfPKdM4JeMvNMLkFfuLcgMIjTivxG1y3DwligaBXrSwKVkkMB4XfswrU7nYT6PO0cIyD_v7vw5kPJP1EafEZGVMJrJJEwS43FVFkLCMIi6eSxyFTYRF4GUbkuXbTpfMxYdivdFdiofA6_JsC-AZXwcE3qXAHpJ3PrH6lYfWm8z0m8PATAQKTqlcEMIYNngNnmnqasBQ_anBj-C7BT4V_B67wOOhc_Vwheq6xKnsI7XfsTgzsmHdFZDVIBCrdw"#;
+        let example = r"API: ec2:ModifyVpcAttribute You are not authorized to perform this operation. Encoded authorization failure message: g1-YvnBabE1x9q868e9rU4VX9gFjPpt31dEvX6uYDMWmdkou9pGLq85c3Wy4IAr3CwKrF8Jqu0aIkiy0TBM5SU22pSjE-gzZuP1dg5rvyhI1fl5DBB4DiDyRmZpOjovE2w0MMxuM4QFqf6zAtlbCtwdCYVxHwTpKrlkQAJEr40twnTPWe1_Vh-YRfprV9RBis8nReUcf87GV1oGFxjLujid4oOAinD-NmpIUR5VLCw2ycoOZihPR_unBC9stRioVeYiBg-Q1T5IU-J-xEQK092YuR-H4vqMm5Nwg4l1kN10t8pbFb_YopmILVfvh-ViLBbzE0cO6ZlvLvcMcB8crsbgLP10H05hPtHDIGUMwc_xM-y_9SUAcrVUfPKdM4JeMvNMLkFfuLcgMIjTivxG1y3DwligaBXrSwKVkkMB4XfswrU7nYT6PO0cIyD_v7vw5kPJP1EafEZGVMJrJJEwS43FVFkLCMIi6eSxyFTYRF4GUbkuXbTpfMxYdivdFdiofA6_JsC-AZXwcE3qXAHpJ3PrH6lYfWm8z0m8PATAQKTqlcEMIYNngNnmnqasBQ_anBj-C7BT4V_B67wOOhc_Vwheq6xKnsI7XfsTgzsmHdFZDVIBCrdw";
         assert_eq!(
             StatusReasonDetail::new(example),
             Some(StatusReasonDetail::MissingPermission(MissingPermission {
@@ -278,7 +284,7 @@ mod tests {
             }))
         );
 
-        let example = r#"API: s3:CreateBucket Access Denied"#;
+        let example = r"API: s3:CreateBucket Access Denied";
         assert_eq!(
             StatusReasonDetail::new(example),
             Some(StatusReasonDetail::MissingPermission(MissingPermission {
@@ -299,7 +305,7 @@ mod tests {
         );
 
         let example =
-            r#"The following resource(s) failed to create: [Vpc, Fs]. Rollback requested by user."#;
+            r"The following resource(s) failed to create: [Vpc, Fs]. Rollback requested by user.";
         let detail = StatusReasonDetail::new(example).unwrap();
         assert_eq!(
             detail,

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+stacks=$(
+  aws cloudformation list-stacks \
+    --stack-status-filter REVIEW_IN_PROGRESS ROLLBACK_FAILED ROLLBACK_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+    --query "StackSummaries[?starts_with(StackName, 'cloudformatious-testing-')].StackName" \
+    --output text
+)
+for stack in $stacks ; do
+  aws cloudformation delete-stack --stack-name "$stack"
+done

--- a/tests/it/common.rs
+++ b/tests/it/common.rs
@@ -52,31 +52,11 @@ pub const NON_EMPTY_TEMPLATE: &str = r#"{
     }
 }"#;
 
-pub const MISSING_PERMISSION_1_TEMPLATE: &str = r#"{
-    "Resources": {
-        "Bucket": {
-            "Type": "AWS::S3::Bucket",
-            "Properties": {}
-        }
-    }
-}"#;
-
-pub const MISSING_PERMISSION_2_TEMPLATE: &str = r#"{
+pub const MISSING_PERMISSION_TEMPLATE: &str = r#"{
   "Resources": {
     "Fs": {
       "Type": "AWS::EFS::FileSystem",
       "Properties": {}
-    }
-  }
-}"#;
-
-pub const AUTHORIZATION_FAILURE_TEMPLATE: &str = r#"{
-  "Resources": {
-    "Vpc": {
-      "Type": "AWS::EC2::VPC",
-      "Properties": {
-        "CidrBlock": "0.0.0.0/16"
-      }
     }
   }
 }"#;

--- a/tests/it/status_reasons.rs
+++ b/tests/it/status_reasons.rs
@@ -6,43 +6,8 @@ use cloudformatious::{
 };
 
 use crate::common::{
-    clean_up, generated_name, get_client, get_sdk_config, AUTHORIZATION_FAILURE_TEMPLATE,
-    MISSING_PERMISSION_1_TEMPLATE, MISSING_PERMISSION_2_TEMPLATE,
+    clean_up, generated_name, get_client, get_sdk_config, MISSING_PERMISSION_TEMPLATE,
 };
-
-#[tokio::test]
-async fn status_reason_missing_permission_no_principal() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client().await;
-
-    let stack_name = generated_name();
-    let input = ApplyStackInput::new(
-        &stack_name,
-        TemplateSource::inline(MISSING_PERMISSION_1_TEMPLATE),
-    );
-    let error = client.apply_stack(input).await.unwrap_err();
-
-    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
-    assert_eq!(failure.stack_status, StackStatus::RollbackComplete);
-
-    let status_reason = assert_matches!(
-        &failure.resource_events[..],
-        [(ResourceStatus::CreateFailed, status)] if status.logical_resource_id() == "Bucket" => {
-            status.resource_status_reason()
-        }
-    );
-    let missing_permission = assert_matches!(
-      status_reason.detail(),
-      Some(StatusReasonDetail::MissingPermission(missing_permission)) => missing_permission
-    );
-
-    assert_eq!(missing_permission.permission, "s3:CreateBucket");
-    assert_eq!(missing_permission.principal, None);
-    assert!(missing_permission.encoded_authorization_message.is_none());
-
-    clean_up(stack_name).await?;
-
-    Ok(())
-}
 
 #[tokio::test]
 async fn status_reason_missing_permission_with_principal() -> Result<(), Box<dyn std::error::Error>>
@@ -56,7 +21,7 @@ async fn status_reason_missing_permission_with_principal() -> Result<(), Box<dyn
     let stack_name = generated_name();
     let input = ApplyStackInput::new(
         &stack_name,
-        TemplateSource::inline(MISSING_PERMISSION_2_TEMPLATE),
+        TemplateSource::inline(MISSING_PERMISSION_TEMPLATE),
     );
     let error = client.apply_stack(input).await.unwrap_err();
 
@@ -80,40 +45,6 @@ async fn status_reason_missing_permission_with_principal() -> Result<(), Box<dyn
     );
     assert_eq!(missing_permission.principal, identity.arn.as_deref());
     assert!(missing_permission.encoded_authorization_message.is_none());
-
-    clean_up(stack_name).await?;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn status_reason_authorization_failure() -> Result<(), Box<dyn std::error::Error>> {
-    let client = get_client().await;
-
-    let stack_name = generated_name();
-    let input = ApplyStackInput::new(
-        &stack_name,
-        TemplateSource::inline(AUTHORIZATION_FAILURE_TEMPLATE),
-    );
-    let error = client.apply_stack(input).await.unwrap_err();
-
-    let failure = assert_matches!(error, ApplyStackError::Failure(failure) => failure);
-    assert_eq!(failure.stack_status, StackStatus::RollbackComplete);
-
-    let status_reason = assert_matches!(
-        &failure.resource_events[..],
-        [(ResourceStatus::CreateFailed, status)] if status.logical_resource_id() == "Vpc" => {
-            status.resource_status_reason()
-        }
-    );
-    let encoded_message = assert_matches!(
-      status_reason.detail(),
-      Some(StatusReasonDetail::AuthorizationFailure(m)) => m
-    );
-
-    let sdk_config = get_sdk_config().await;
-    let decoded_message = encoded_message.decode(&sdk_config).await?;
-    assert_eq!(decoded_message["context"]["action"], "ec2:CreateVpc");
 
     clean_up(stack_name).await?;
 


### PR DESCRIPTION
- 245bba7 **chore: add a script to cleanup after failed tests**


- be91831 **chore: remove unreproducible test cases**

  This may obviate some of the status reason analysis, but we won't change
  the source until we upgrade the AWS SDK.

- 178ab75 **chore: fix new clippy lints**


- baa82d2 **chore!: upgrade aws-sdk crates**

  BREAKING CHANGE: The crate must now be configured with an `SdkConfig`
  compatible with `aws-types@1`.
