### PR TITLE
Nested stack events

### DIFF
--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -610,7 +610,7 @@ impl fmt::Display for ApplyStackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CloudFormationApi(error) => {
-                write!(f, "CloudFormation API error: {error}")
+                write!(f, "CloudFormation API error: {error:#?}")
             }
             Self::Blocked { status } => {
                 write!(

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -609,7 +609,7 @@ pub enum ResourceTargetDefinition {
     /// A change to the resource's properties.
     Properties {
         /// The name of the property.
-        name: String,
+        name: Option<String>,
 
         /// Indicates whether a change to this property causes the resource to be recreated.
         requires_recreation: RequiresRecreation,
@@ -641,9 +641,7 @@ impl ResourceTargetDefinition {
             .expect("ResourceTargetDefinition without attribute");
         match attribute {
             aws_sdk_cloudformation::types::ResourceAttribute::Properties => Self::Properties {
-                name: target
-                    .name
-                    .expect("ResourceTargetDefinition with attribute \"Properties\" without name"),
+                name: target.name,
                 requires_recreation: target
                     .requires_recreation
                     .expect(concat!(

--- a/src/event.rs
+++ b/src/event.rs
@@ -116,6 +116,12 @@ impl StackEvent {
         self.details().stack_name.as_str()
     }
 
+    /// Get the alias for a nested stack.
+    #[must_use]
+    pub fn stack_alias(&self) -> Option<&str> {
+        self.details().stack_alias.as_deref()
+    }
+
     /// Get the time the status was updated.
     #[must_use]
     pub fn timestamp(&self) -> &DateTime<Utc> {
@@ -139,7 +145,10 @@ impl StackEvent {
         }
     }
 
-    pub(crate) fn from_sdk(event: aws_sdk_cloudformation::types::StackEvent) -> Self {
+    pub(crate) fn from_sdk(
+        stack_alias: Option<String>,
+        event: aws_sdk_cloudformation::types::StackEvent,
+    ) -> Self {
         let is_stack = event.physical_resource_id.as_deref() == event.stack_id.as_deref();
         let resource_status = event
             .resource_status
@@ -157,6 +166,7 @@ impl StackEvent {
                 .expect("StackEvent without resource_type"),
             stack_id: event.stack_id.expect("StackEvent without stack_id"),
             stack_name: event.stack_name.expect("StackEvent without stack_name"),
+            stack_alias,
             timestamp: event
                 .timestamp
                 .expect("StackEvent without timestamp")
@@ -225,6 +235,11 @@ pub struct StackEventDetails {
     /// The name associated with the stack.
     pub stack_name: String,
 
+    /// The alias for a nested stack.
+    ///
+    /// This is built up of the logical IDs of the nested stacks.
+    pub stack_alias: Option<String>,
+
     /// Time the status was updated.
     pub timestamp: DateTime<Utc>,
 }
@@ -291,6 +306,12 @@ impl StackEventDetails {
     #[must_use]
     pub fn stack_name(&self) -> &str {
         self.stack_name.as_str()
+    }
+
+    /// Get the alias for a nested stack.
+    #[must_use]
+    pub fn stack_alias(&self) -> Option<&str> {
+        self.stack_alias.as_deref()
     }
 
     /// Get the time the status was updated.

--- a/tests/it/change_set_detail.rs
+++ b/tests/it/change_set_detail.rs
@@ -90,7 +90,7 @@ async fn secrets_manager_secret_tags_only() -> Result<(), Box<dyn std::error::Er
     assert!(!targets.is_empty());
     assert!(targets.iter().all(|target| matches!(
         target,
-        ResourceTargetDefinition::Properties { name, .. } if name == "Tags"
+        ResourceTargetDefinition::Properties { name, .. } if name.as_deref() == Some("Tags")
     )));
 
     clean_up(stack_name).await?;


### PR DESCRIPTION
- 637b47f **fix: use debug representation for generic cfn API errors**

  It's not clear if something changed upstream or if this never really
  worked, but the display output from CloudFormation errors would often
  just be "service error".

- df324bd **fix: allow `ResourceTargetDefinition` without name for attribute `Properties`**

  This situation arose when describing the changeset of a nested stack.
  It's not clear if this was triggered by an upstream change or has always
  been an ommission.

- 8311a89 **feat: report nested stack events**

  Events from nested stacks are now reported, with a "stack alias" built
  built from the logical IDs of the nested stacks combined with `/` (e.g.
  `child/grantchild/Resource`).
