### PR TITLE
Resume

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -43,7 +43,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -66,7 +66,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -89,7 +89,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -112,7 +112,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Test cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: test-${{ hashFiles('Cargo.lock') }}
           path: target

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -294,7 +294,7 @@ impl ApplyStackInput {
 ///   - If you have IAM resources, you can specify either capability.
 ///   - If you have IAM resources with custom names, you *must* specify `CAPABILITY_NAMED_IAM`.
 ///   - If you don't specify either of these capabilities, AWS CloudFormation returns an
-///    `InsufficientCapabilities` error.
+///     `InsufficientCapabilities` error.
 ///
 ///   If you stack template contains these resources, we recommend that you review all
 ///   permissions associated with them and edit their permissions if necessary.

--- a/src/apply_stack.rs
+++ b/src/apply_stack.rs
@@ -13,11 +13,12 @@ use futures_util::{Stream, TryFutureExt, TryStreamExt};
 
 use crate::{
     change_set::{
-        create_change_set, execute_change_set, ChangeSet, ChangeSetType, ChangeSetWithType,
-        CreateChangeSetError, ExecuteChangeSetError,
+        create_change_set, execute_change_set, resume_execute_change_set, ChangeSet, ChangeSetType,
+        ChangeSetWithType, CreateChangeSetError, ExecuteChangeSetError,
     },
     stack::StackOperationError,
-    BlockedStackStatus, ChangeSetStatus, StackEvent, StackFailure, StackStatus, StackWarning, Tag,
+    BlockedStackStatus, ChangeSetStatus, ResumeInput, StackEvent, StackFailure, StackStatus,
+    StackWarning, Tag,
 };
 
 /// The input for the `apply_stack` operation.
@@ -717,6 +718,49 @@ impl<'client> ApplyStack<'client> {
             };
 
             let output = describe_output(client, stack_id, change_set_id).await?;
+
+            match warning {
+                Some(warning) => {
+                    Err(ApplyStackError::Warning { output, warning })?;
+                    unreachable!()
+                }
+                None => yield ApplyStackEvent::Output(output),
+            };
+        };
+        Self {
+            event_stream: Box::pin(event_stream),
+            output: None,
+        }
+    }
+
+    pub(crate) fn resume(
+        client: &'client aws_sdk_cloudformation::Client,
+        input: ResumeInput,
+    ) -> Self {
+        let event_stream = try_stream! {
+            let (change_set_id, mut operation) =
+                resume_execute_change_set(client, input.stack_id.clone())
+                    .await
+                    .map_err(ApplyStackError::from_sdk_error)?;
+
+            while let Some(event) = operation
+                .try_next()
+                .await
+                .map_err(ApplyStackError::from_sdk_error)?
+            {
+                yield ApplyStackEvent::Event(event);
+            }
+
+            let warning = match operation.verify() {
+                Err(StackOperationError::Failure(failure)) => {
+                    Err(ApplyStackError::Failure(failure))?;
+                    unreachable!()
+                }
+                Ok(()) => None,
+                Err(StackOperationError::Warning(warning)) => Some(warning),
+            };
+
+            let output = describe_output(client, input.stack_id, change_set_id).await?;
 
             match warning {
                 Some(warning) => {

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -463,7 +463,7 @@ pub use modify_scope::ModifyScope;
 /// A change that AWS CloudFormation will make to a resource.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceChangeDetail {
-    /// The group to which the CausingEntity value belongs.
+    /// The identity of the entity that triggered this change.
     ///
     /// This will not be present if the change source cannot be described by CloudFormation's
     /// limited vocabulary, such as tags supplied when creating a change set.

--- a/src/change_set.rs
+++ b/src/change_set.rs
@@ -1,15 +1,21 @@
 //! Helpers for working with change sets.
 
-use std::{convert::TryFrom, fmt, time::Duration};
+use std::{
+    convert::TryFrom,
+    fmt,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use aws_sdk_cloudformation::{
+    config::{http::HttpResponse, Intercept},
     error::{ProvideErrorMetadata, SdkError},
     operation::create_change_set::builders::CreateChangeSetFluentBuilder,
     operation::describe_change_set::{DescribeChangeSetError, DescribeChangeSetOutput},
     types::{Change, ChangeAction},
 };
 use aws_smithy_types_convert::date_time::DateTimeExt;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use enumset::EnumSet;
 use futures_util::TryFutureExt;
 use regex::Regex;
@@ -861,6 +867,104 @@ pub(crate) async fn execute_change_set(
             ChangeSetType::Create => check_create_progress,
             ChangeSetType::Update => check_update_progress,
         },
+    ))
+}
+
+pub(crate) async fn resume_execute_change_set(
+    client: &aws_sdk_cloudformation::Client,
+    stack_id: String,
+) -> Result<
+    (
+        String,
+        StackOperation<'_, impl Fn(StackStatus) -> StackOperationStatus + Unpin>,
+    ),
+    SdkError<aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError>,
+> {
+    #[derive(Clone, Debug, Default)]
+    struct GetResponse {
+        response: Arc<Mutex<Option<HttpResponse>>>,
+    }
+
+    impl Intercept for GetResponse {
+        fn name(&self) -> &'static str {
+            "GetResponse"
+        }
+
+        fn read_after_execution(
+            &self,
+            context: &aws_sdk_cloudformation::config::interceptors::FinalizerInterceptorContextRef<
+                '_,
+            >,
+            _runtime_components: &aws_sdk_cloudformation::config::RuntimeComponents,
+            _cfg: &mut aws_sdk_cloudformation::config::ConfigBag,
+        ) -> Result<(), aws_sdk_cloudformation::error::BoxError> {
+            if let Some(res) = context.response() {
+                if let Some(body) = res.body().try_clone() {
+                    let mut res_clone = HttpResponse::new(res.status(), body);
+                    *res_clone.headers_mut() = res.headers().clone();
+                    *self.response.lock().unwrap() = Some(res_clone);
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let get_response = GetResponse::default();
+    let result = client
+        .describe_stacks()
+        .stack_name(&stack_id)
+        .customize()
+        .interceptor(get_response.clone())
+        .send()
+        .await?;
+
+    let stack =
+        result
+            .stacks
+            .as_ref()
+            .and_then(|stacks| {
+                let (stack, others) = stacks.split_first()?;
+
+                assert!(
+                    others.is_empty(),
+                    "unexpected response from describe stacks (multiple stacks)"
+                );
+
+                Some(stack)
+            })
+            .ok_or_else(|| {
+                SdkError::service_error(
+                aws_sdk_cloudformation::operation::describe_stacks::DescribeStacksError::unhandled(
+                    "stack not found",
+                ),
+                get_response.response.lock().unwrap().take().expect("BUG: no response intercepted"),
+            )
+            })?;
+
+    let stack_id = stack.stack_id.clone().expect("Stack without stack_id");
+    let change_set_id = stack
+        .change_set_id
+        .clone()
+        .expect("Stack without change_set_id");
+    let started_at = stack
+        .last_updated_time
+        .or(stack.creation_time)
+        .expect("Stack without creation_time")
+        .to_chrono_utc()
+        .expect("invalid timestamp")
+        - TimeDelta::seconds(1);
+
+    Ok((
+        change_set_id,
+        StackOperation::new(
+            client,
+            stack_id,
+            started_at,
+            |status| match check_create_progress(status) {
+                StackOperationStatus::Unexpected => check_update_progress(status),
+                status => status,
+            },
+        ),
     ))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,16 @@ impl Client {
         ApplyStack::new(&self.inner, input)
     }
 
+    /// Resume processing an in-progress `apply_stack` operation.
+    ///
+    /// The returned `Future` can be used to simply wait for the operation to complete. You can also
+    /// use [`ApplyStack::events`] to get a `Stream` of the stack events that occur during the
+    /// operation. See [`ApplyStack`] for more details.
+    #[must_use]
+    pub fn resume_apply_stack(&self, input: ResumeInput) -> ApplyStack {
+        ApplyStack::resume(&self.inner, input)
+    }
+
     /// Delete a CloudFormation stack from an AWS environment.
     ///
     /// This is an idempotent operation that will delete the indicated stack if it exists, or do
@@ -65,6 +75,41 @@ impl Client {
     #[must_use]
     pub fn delete_stack(&self, input: DeleteStackInput) -> DeleteStack {
         DeleteStack::new(&self.inner, input)
+    }
+}
+
+/// The input for [`resume_apply_stack`](Client::resume_apply_stack).
+///
+/// You can create an input via the [`new`](Self::new) associated function. Setters are available
+/// to make construction ergonomic.
+#[derive(Clone, Debug)]
+pub struct ResumeInput {
+    /// The unique identifier for the operation.
+    ///
+    /// All events triggered by a given stack operation are assigned the same client request token,
+    /// which are used to track operations.
+    pub client_request_token: Option<String>,
+
+    /// The ID (or name) of the stack.
+    pub stack_id: String,
+}
+
+impl ResumeInput {
+    /// Construct an input for the given `stack_id`.
+    pub fn new(stack_id: impl Into<String>) -> Self {
+        Self {
+            stack_id: stack_id.into(),
+            client_request_token: None,
+        }
+    }
+
+    /// Set the value for `client_request_token`.
+    ///
+    /// **Note:** this consumes and returns `self` for chaining.
+    #[must_use]
+    pub fn set_client_request_token(mut self, client_request_token: impl Into<String>) -> Self {
+        self.client_request_token = Some(client_request_token.into());
+        self
     }
 }
 

--- a/tests/it/apply_stack.rs
+++ b/tests/it/apply_stack.rs
@@ -2,8 +2,8 @@ use futures_util::StreamExt;
 
 use cloudformatious::{
     change_set::{Action, ExecutionStatus},
-    ApplyStackError, ApplyStackInput, ChangeSetStatus, ResourceStatus, StackFailure, StackStatus,
-    TemplateSource,
+    ApplyStackError, ApplyStackInput, ChangeSetStatus, ResourceStatus, ResumeInput, StackFailure,
+    StackStatus, TemplateSource,
 };
 
 use crate::common::{
@@ -537,6 +537,68 @@ async fn apply_to_update_rollback_complete_idempotent() -> Result<(), Box<dyn st
     assert_eq!(output.stack_status, StackStatus::UpdateRollbackComplete);
 
     clean_up(failure.stack_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn resume_fut_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let client = get_client().await;
+
+    let stack_name = generated_name();
+    let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
+    let mut apply = client.apply_stack(input);
+
+    apply.change_set().await?;
+
+    let event = apply.events().next().await.ok_or("no stack events")?;
+
+    let input = ResumeInput::new(event.stack_id());
+    let output = client.resume_apply_stack(input).await?;
+    assert_eq!(output.stack_status, StackStatus::CreateComplete);
+
+    clean_up(stack_name).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn resume_stream_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let client = get_client().await;
+
+    let stack_name = generated_name();
+    let input = ApplyStackInput::new(&stack_name, TemplateSource::inline(EMPTY_TEMPLATE));
+    let mut apply = client.apply_stack(input);
+
+    apply.change_set().await?;
+
+    let event = apply.events().next().await.ok_or("no stack events")?;
+
+    let input = ResumeInput::new(event.stack_id());
+    let mut apply = client.resume_apply_stack(input);
+
+    let events: Vec<_> = apply
+        .events()
+        .map(|event| {
+            (
+                event.logical_resource_id().to_string(),
+                event.resource_status().to_string(),
+            )
+        })
+        .collect()
+        .await;
+    let output = apply.await?;
+
+    assert_eq!(output.stack_status, StackStatus::CreateComplete);
+    assert_eq!(
+        events,
+        vec![
+            (stack_name.clone(), "CREATE_IN_PROGRESS".to_string()),
+            (stack_name.clone(), "CREATE_COMPLETE".to_string()),
+        ]
+    );
+
+    clean_up(stack_name).await?;
 
     Ok(())
 }


### PR DESCRIPTION
- 070d9a9 **chore: fix new clippy lints**

  This included a rewrite of a doc comment that referred to a value that is
  not present in our API (the `CausingEntity` is part of the `ChangeSource`
  enum).

- 6fdf578 **feat: add `Client::resume_apply_stack`**

  This essentially runs the `apply_stack` logic, except that the change set
  creation is skipped.
  
  One curiosity is that this could be ran against a stack that settled some
  time in the past and it would still replay the events from the operation.
  This suggests the naming might not be quite right, but the functionality
  could be useful.

- d03eeeb **chore: upgrade `actions/cache`**

  `v2` is no longer available.
